### PR TITLE
Resolve StyleCop analyser warnings.

### DIFF
--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -4,8 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
-
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
+++ b/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
@@ -6,12 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>c74223ed-c414-48c4-9b8f-3529e95faa61</UserSecretsId>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
-	  <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
-
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-	<ItemGroup>
-     <InternalsVisibleTo Include="Streetcode.XIntegrationTest" />
-</ItemGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Streetcode.XIntegrationTest" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />

--- a/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
+++ b/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I decided not to change settings.ruleset for now. It’s better to collect more information about which rules bother you the most when working on code.
However, I added the currently active settings.ruleset to the Streetcode.XUnitTest project to significantly reduce the number of warnings about code non-compliance with the rules.
In addition, I edited the project files Streetcode.BLL and Streetcode.WebApi - removed unnecessary lines and aligned the text