### PR TITLE
Enhancement/resolve stylecop analyser warnings And bring the test code to these requirements

### DIFF
--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -4,8 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
-
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
+++ b/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
@@ -6,12 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>c74223ed-c414-48c4-9b8f-3529e95faa61</UserSecretsId>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
-	  <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
-
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-	<ItemGroup>
-     <InternalsVisibleTo Include="Streetcode.XIntegrationTest" />
-</ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Streetcode.XIntegrationTest" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAllAudioHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAllAudioHandlerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Audio;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
@@ -10,280 +12,277 @@ using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Audio
+public class GetAllAudioHandlerTests
 {
-    public class GetAllAudioHandlerTests
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IBlobService> _mockBlobService;
+
+    public GetAllAudioHandlerTests()
     {
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IBlobService> _mockBlobService;
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockBlobService = new Mock<IBlobService>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
 
-        public GetAllAudioHandlerTests()
+    [Fact]
+    public async Task Handle_ReturnsOkResult_WithListOfAudios_WhenAudiosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenAudiosNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_LogsError_WhenAudiosNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        _mockLogger.Verify(
+            logger => logger.LogError(
+                It.IsAny<GetAllAudiosQuery>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCollectionOfCorrectCount_WhenAudiosFound()
+    {
+        // Arrange
+        var mockVideo = GetAudioList();
+        var expectedCount = mockVideo.Count;
+
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+        var actualCount = result.Value.Count();
+
+        // Assert
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public async Task Handle_MapperShouldMapOnlyOnce_WhenAudiosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper =>
+            mapper.Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Audio>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnCollectionOfAudioDto_WhenAudiosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<List<AudioDTO>>(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenAudiosAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenAudiosAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllAudiosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        var expectedError = "Cannot find any audios";
+
+        // Act
+        var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedError, result.Errors.First().Message);
+    }
+
+    private static List<Streetcode.DAL.Entities.Media.Audio> GetAudioList()
+    {
+        return new List<Streetcode.DAL.Entities.Media.Audio>
         {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockBlobService = new Mock<IBlobService>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsOkResult_WithListOfAudios_WhenAudiosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenAudiosNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_LogsError_WhenAudiosNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            _mockLogger.Verify(
-                logger => logger.LogError(
-                    It.IsAny<GetAllAudiosQuery>(),
-                    It.IsAny<string>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsCollectionOfCorrectCount_WhenAudiosFound()
-        {
-            // Arrange
-            var mockVideo = GetAudioList();
-            var expectedCount = mockVideo.Count;
-
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-            var actualCount = result.Value.Count();
-
-            // Assert
-            Assert.Equal(expectedCount, actualCount);
-        }
-
-        [Fact]
-        public async Task Handle_MapperShouldMapOnlyOnce_WhenAudiosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper =>
-                mapper.Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Audio>>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldReturnCollectionOfAudioDto_WhenAudiosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<List<AudioDTO>>(result.Value);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenAudiosAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenAudiosAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllAudiosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            var expectedError = "Cannot find any audios";
-
-            // Act
-            var result = await handler.Handle(new GetAllAudiosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(expectedError, result.Errors.First().Message);
-        }
-
-        private static List<Streetcode.DAL.Entities.Media.Audio> GetAudioList()
-        {
-            return new List<Streetcode.DAL.Entities.Media.Audio>
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Title = "Audio Title 1",
-                    BlobName = "audio1.mp3",
-                    MimeType = "audio/mpeg",
-                    Base64 = "base64_encoded_audio_data_1",
-                },
-                new ()
-                {
-                    Id = 2,
-                    Title = "Audio Title 2",
-                    BlobName = "audio2.mp3",
-                    MimeType = "audio/mpeg",
-                    Base64 = "base64_encoded_audio_data_2",
-                },
-                new ()
-                {
-                    Id = 3,
-                    Title = "Audio Title 3",
-                    BlobName = "audio3.mp3",
-                    MimeType = "audio/mpeg",
-                    Base64 = "base64_encoded_audio_data_3",
-                },
-            };
-        }
-
-        private static List<AudioDTO> GetAudioDtoList()
-        {
-            return new List<AudioDTO>
+                Id = 1,
+                Title = "Audio Title 1",
+                BlobName = "audio1.mp3",
+                MimeType = "audio/mpeg",
+                Base64 = "base64_encoded_audio_data_1",
+            },
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Description = "Description 1",
-                    BlobName = "audio1.mp3",
-                    Base64 = "base64_encoded_data_1",
-                    MimeType = "audio/mpeg",
-                },
-                new ()
-                {
-                    Id = 2,
-                    Description = "Description 2",
-                    BlobName = "audio2.mp3",
-                    Base64 = "base64_encoded_data_2",
-                    MimeType = "audio/mpeg"
-                },
-                new ()
-                {
-                    Id = 3,
-                    Description = "Description 3",
-                    BlobName = "audio3.mp3",
-                    Base64 = "base64_encoded_data_3",
-                    MimeType = "audio/mpeg",
-                },
-            };
-        }
+                Id = 2,
+                Title = "Audio Title 2",
+                BlobName = "audio2.mp3",
+                MimeType = "audio/mpeg",
+                Base64 = "base64_encoded_audio_data_2",
+            },
+            new ()
+            {
+                Id = 3,
+                Title = "Audio Title 3",
+                BlobName = "audio3.mp3",
+                MimeType = "audio/mpeg",
+                Base64 = "base64_encoded_audio_data_3",
+            },
+        };
+    }
 
-        private void MockMapperSetup()
+    private static List<AudioDTO> GetAudioDtoList()
+    {
+        return new List<AudioDTO>
         {
-            _mockMapper.Setup(x => x
-                .Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Audio>>()))
-                .Returns(GetAudioDtoList());
-        }
+            new ()
+            {
+                Id = 1,
+                Description = "Description 1",
+                BlobName = "audio1.mp3",
+                Base64 = "base64_encoded_data_1",
+                MimeType = "audio/mpeg",
+            },
+            new ()
+            {
+                Id = 2,
+                Description = "Description 2",
+                BlobName = "audio2.mp3",
+                Base64 = "base64_encoded_data_2",
+                MimeType = "audio/mpeg"
+            },
+            new ()
+            {
+                Id = 3,
+                Description = "Description 3",
+                BlobName = "audio3.mp3",
+                Base64 = "base64_encoded_data_3",
+                MimeType = "audio/mpeg",
+            },
+        };
+    }
 
-        private void MockRepositorySetupReturnsData()
-        {
-            _mockRepositoryWrapper.Setup(x => x.AudioRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()))
-                .ReturnsAsync(GetAudioList());
-        }
+    private void MockMapperSetup()
+    {
+        _mockMapper.Setup(x => x
+            .Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Audio>>()))
+            .Returns(GetAudioDtoList());
+    }
 
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.AudioRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Audio>?)null);
-        }
+    private void MockRepositorySetupReturnsData()
+    {
+        _mockRepositoryWrapper.Setup(x => x.AudioRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Audio, bool>>>(),
+                It.IsAny<Func<IQueryable<Audio>,
+            IIncludableQueryable<Audio, object>>>()))
+            .ReturnsAsync(GetAudioList());
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.AudioRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Audio, bool>>>(),
+                It.IsAny<Func<IQueryable<Audio>,
+            IIncludableQueryable<Audio, object>>>()))
+            .ReturnsAsync((IEnumerable<Audio>?)null);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAudioByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAudioByIdHandlerTests.cs
@@ -1,215 +1,212 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Audio;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.Media.Audio;
 using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.MediatR.Media.Audio.GetAll;
 using Streetcode.BLL.MediatR.Media.Audio.GetById;
 using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Audio
+public class GetAudioByIdHandlerTests
 {
-    public class GetAudioByIdHandlerTests
-    {        
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IBlobService> _mockBlobService;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IBlobService> _mockBlobService;
 
-        public GetAudioByIdHandlerTests()
-        {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockBlobService = new Mock<IBlobService>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsAudio(id);
-            MockMapperSetup(id);
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenAudioExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsAudio(id);
-            MockMapperSetup(id);
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockRepositoryWrapper.Verify(
-                repo =>
-                repo.AudioRepository.GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_MapperCallMapOnlyOnce_WhenAudioExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsAudio(id);
-            MockMapperSetup(id);
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper => mapper.Map<AudioDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Audio>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsVideoWithCorrectId_WhenAudioExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsAudio(id);
-            MockMapperSetup(id);
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object); ;
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(id, result.Value.Id);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnAudioDto_WhenAudioExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsAudio(id);
-            MockMapperSetup(id);
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<AudioDTO>(result.Value);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnFail_WhenAudioIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenAudioIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAudioByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            var expectedMessage = $"Cannot find an audio with corresponding id: {id}";
-
-            // Act
-            var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
-            var actualMessage = result.Errors.First().Message;
-
-            // Assert
-            Assert.Equal(expectedMessage, actualMessage);
-        }
-
-        private void MockMapperSetup(int id)
-        {
-            _mockMapper.Setup(x => x
-                .Map<AudioDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Audio>()))
-                .Returns(new AudioDTO { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsAudio(int id)
-        {
-            _mockRepositoryWrapper.Setup(x => x.AudioRepository
-                .GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()))
-                .ReturnsAsync(new Streetcode.DAL.Entities.Media.Audio { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.AudioRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Audio>?)null);
-        }
+    public GetAudioByIdHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockBlobService = new Mock<IBlobService>();
+        _mockLogger = new Mock<ILoggerService>();
     }
 
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsAudio(id);
+        MockMapperSetup(id);
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenAudioExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsAudio(id);
+        MockMapperSetup(id);
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(
+            repo =>
+            repo.AudioRepository.GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
+               It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
+               IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_MapperCallMapOnlyOnce_WhenAudioExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsAudio(id);
+        MockMapperSetup(id);
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper => mapper.Map<AudioDTO>(It.IsAny<Audio>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsVideoWithCorrectId_WhenAudioExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsAudio(id);
+        MockMapperSetup(id);
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(id, result.Value.Id);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnAudioDto_WhenAudioExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsAudio(id);
+        MockMapperSetup(id);
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<AudioDTO>(result.Value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnFail_WhenAudioIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenAudioIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAudioByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        var expectedMessage = $"Cannot find an audio with corresponding id: {id}";
+
+        // Act
+        var result = await handler.Handle(new GetAudioByIdQuery(id), CancellationToken.None);
+        var actualMessage = result.Errors.First().Message;
+
+        // Assert
+        Assert.Equal(expectedMessage, actualMessage);
+    }
+
+    private void MockMapperSetup(int id)
+    {
+        _mockMapper.Setup(x => x
+            .Map<AudioDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Audio>()))
+            .Returns(new AudioDTO { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsAudio(int id)
+    {
+        _mockRepositoryWrapper.Setup(x => x.AudioRepository
+            .GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Audio, bool>>>(),
+               It.IsAny<Func<IQueryable<Audio>,
+               IIncludableQueryable<Audio, object>>>()))
+            .ReturnsAsync(new Audio { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.AudioRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Audio, bool>>>(),
+                It.IsAny<Func<IQueryable<Audio>,
+            IIncludableQueryable<Audio, object>>>()))
+            .ReturnsAsync((IEnumerable<Audio>?)null);
+    }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Image/GetAllImageHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Image/GetAllImageHandlerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Image;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
@@ -6,279 +8,275 @@ using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Media.Image.GetAll;
-using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Image
+public class GetAllImageHandlerTests
 {
-    public class GetAllImageHandlerTests
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IBlobService> _mockBlobService;
+
+    public GetAllImageHandlerTests()
     {
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IBlobService> _mockBlobService;
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockBlobService = new Mock<IBlobService>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
 
-        public GetAllImageHandlerTests()
+    [Fact]
+    public async Task Handle_ReturnsOkResult_WithListOfImages_WhenImagesFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenImagesNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_LogsError_WhenImagesNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        _mockLogger.Verify(
+            logger => logger.LogError(
+                It.IsAny<GetAllImagesQuery>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCollectionOfCorrectCount_WhenImagesFound()
+    {
+        // Arrange
+        var mockVideo = GetImageList();
+        var expectedCount = mockVideo.Count;
+
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+        var actualCount = result.Value.Count();
+
+        // Assert
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public async Task Handle_MapperShouldMapOnlyOnce_WhenImagesFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper =>
+            mapper.Map<IEnumerable<ImageDTO>>(It.IsAny<IEnumerable<Image>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnCollectionOfImageDto_WhenImagesFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<List<ImageDTO>>(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenImagesAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenImagesAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllImagesHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        var expectedError = "Cannot find any image";
+
+        // Act
+        var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedError, result.Errors.First().Message);
+    }
+
+    private static List<Image> GetImageList()
+    {
+        return new List<Image>
         {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockBlobService = new Mock<IBlobService>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsOkResult_WithListOfImages_WhenImagesFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenImagesNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_LogsError_WhenImagesNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            _mockLogger.Verify(
-                logger => logger.LogError(
-                    It.IsAny<GetAllImagesQuery>(),
-                    It.IsAny<string>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsCollectionOfCorrectCount_WhenImagesFound()
-        {
-            // Arrange
-            var mockVideo = GetImageList();
-            var expectedCount = mockVideo.Count;
-
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-            var actualCount = result.Value.Count();
-
-            // Assert
-            Assert.Equal(expectedCount, actualCount);
-        }
-
-        [Fact]
-        public async Task Handle_MapperShouldMapOnlyOnce_WhenImagesFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper =>
-                mapper.Map<IEnumerable<ImageDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Images.Image>>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldReturnCollectionOfImageDto_WhenImagesFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<List<ImageDTO>>(result.Value);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenImagesAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenImagesAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllImagesHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            var expectedError = "Cannot find any image";
-
-            // Act
-            var result = await handler.Handle(new GetAllImagesQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(expectedError, result.Errors.First().Message);
-        }
-
-        private static List<Streetcode.DAL.Entities.Media.Images.Image> GetImageList()
-        {
-            return new List<Streetcode.DAL.Entities.Media.Images.Image>
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Base64 = "base64_encoded_data_1",
-                    BlobName = "image1.jpg",
-                    MimeType = "image/jpeg",
-                },
-                new ()
-                {
-                    Id = 2,
-                    Base64 = "base64_encoded_data_2",
-                    BlobName = "image2.jpg",
-                    MimeType = "image/jpeg",
-                },
-                new ()
-                {
-                    Id = 3,
-                    Base64 = "base64_encoded_data_3",
-                    BlobName = "image3.jpg",
-                    MimeType = "image/jpeg",
-                },
-            };
-        }
-
-        private static List<ImageDTO> GetImageDtoList()
-        {
-            return new List<ImageDTO>
+                Id = 1,
+                Base64 = "base64_encoded_data_1",
+                BlobName = "image1.jpg",
+                MimeType = "image/jpeg",
+            },
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    BlobName = "image1.jpg",
-                    Base64 = "base64_encoded_data_1",
-                    MimeType = "image/jpeg",
-                },
-                new ()
-                {
-                    Id = 2,
-                    BlobName = "image2.jpg",
-                    Base64 = "base64_encoded_data_2",
-                    MimeType = "image/jpeg",
-                },
-                new ()
-                {
-                    Id = 3,
-                    BlobName = "image3.jpg",
-                    Base64 = "base64_encoded_data_3",
-                    MimeType = "image/jpeg",
-                },
-            };
-        }
+                Id = 2,
+                Base64 = "base64_encoded_data_2",
+                BlobName = "image2.jpg",
+                MimeType = "image/jpeg",
+            },
+            new ()
+            {
+                Id = 3,
+                Base64 = "base64_encoded_data_3",
+                BlobName = "image3.jpg",
+                MimeType = "image/jpeg",
+            },
+        };
+    }
 
-        private void MockMapperSetup()
+    private static List<ImageDTO> GetImageDtoList()
+    {
+        return new List<ImageDTO>
         {
-            _mockMapper.Setup(x => x
-                .Map<IEnumerable<ImageDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Images.Image>>()))
-                .Returns(GetImageDtoList());
-        }
+            new ()
+            {
+                Id = 1,
+                BlobName = "image1.jpg",
+                Base64 = "base64_encoded_data_1",
+                MimeType = "image/jpeg",
+            },
+            new ()
+            {
+                Id = 2,
+                BlobName = "image2.jpg",
+                Base64 = "base64_encoded_data_2",
+                MimeType = "image/jpeg",
+            },
+            new ()
+            {
+                Id = 3,
+                BlobName = "image3.jpg",
+                Base64 = "base64_encoded_data_3",
+                MimeType = "image/jpeg",
+            },
+        };
+    }
 
-        private void MockRepositorySetupReturnsData()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ImageRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Image, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Image>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Image, object>>>()))
-                .ReturnsAsync(GetImageList());
-        }
+    private void MockMapperSetup()
+    {
+        _mockMapper.Setup(x => x
+            .Map<IEnumerable<ImageDTO>>(It.IsAny<IEnumerable<Image>>()))
+            .Returns(GetImageDtoList());
+    }
 
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ImageRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Image, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Image>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Image, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Images.Image>?)null);
-        }
+    private void MockRepositorySetupReturnsData()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ImageRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>,
+            IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync(GetImageList());
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ImageRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>,
+            IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync((IEnumerable<Image>?)null);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Image/GetImageByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Image/GetImageByIdHandlerTests.cs
@@ -1,216 +1,212 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Image;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.MediatR.Media.Image.GetAll;
 using Streetcode.BLL.MediatR.Media.Image.GetById;
-using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Image
+public class GetImageByIdHandlerTests
 {
-    public class GetImageByIdHandlerTests
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IBlobService> _mockBlobService;
+
+    public GetImageByIdHandlerTests()
     {
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IBlobService> _mockBlobService;
-
-        public GetImageByIdHandlerTests()
-        {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockBlobService = new Mock<IBlobService>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsImage(id);
-            MockMapperSetup(id);
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenImageExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsImage(id);
-            MockMapperSetup(id);
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockRepositoryWrapper.Verify(
-                repo =>
-                repo.ImageRepository.GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Image, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Image>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Image, object>>>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_MapperCallMapOnlyOnce_WhenImageExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsImage(id);
-            MockMapperSetup(id);
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper => mapper.Map<ImageDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Images.Image>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsImageWithCorrectId_WhenImageExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsImage(id);
-            MockMapperSetup(id);
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object); ;
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(id, result.Value.Id);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnImageDto_WhenImageExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsImage(id);
-            MockMapperSetup(id);
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<ImageDTO>(result.Value);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnFail_WhenImageIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenImageIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetImageByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockBlobService.Object,
-                _mockLogger.Object);
-
-            var expectedMessage = $"Cannot find a image with corresponding id: {id}";
-
-            // Act
-            var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
-            var actualMessage = result.Errors.First().Message;
-
-            // Assert
-            Assert.Equal(expectedMessage, actualMessage);
-        }
-
-        private void MockMapperSetup(int id)
-        {
-            _mockMapper.Setup(x => x
-                .Map<ImageDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Images.Image>()))
-                .Returns(new ImageDTO { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsImage(int id)
-        {
-            _mockRepositoryWrapper.Setup(x => x.ImageRepository
-                .GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Image, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Image>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Image, object>>>()))
-                .ReturnsAsync(new Streetcode.DAL.Entities.Media.Images.Image { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ImageRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Image, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Image>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Image, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Images.Image>?)null);
-        }
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockBlobService = new Mock<IBlobService>();
+        _mockLogger = new Mock<ILoggerService>();
     }
 
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsImage(id);
+        MockMapperSetup(id);
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenImageExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsImage(id);
+        MockMapperSetup(id);
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(
+            repo =>
+            repo.ImageRepository.GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Image, bool>>>(),
+               It.IsAny<Func<IQueryable<Image>,
+               IIncludableQueryable<Image, object>>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_MapperCallMapOnlyOnce_WhenImageExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsImage(id);
+        MockMapperSetup(id);
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper => mapper.Map<ImageDTO>(It.IsAny<Image>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsImageWithCorrectId_WhenImageExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsImage(id);
+        MockMapperSetup(id);
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(id, result.Value.Id);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnImageDto_WhenImageExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsImage(id);
+        MockMapperSetup(id);
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<ImageDTO>(result.Value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnFail_WhenImageIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenImageIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetImageByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockBlobService.Object,
+            _mockLogger.Object);
+
+        var expectedMessage = $"Cannot find a image with corresponding id: {id}";
+
+        // Act
+        var result = await handler.Handle(new GetImageByIdQuery(id), CancellationToken.None);
+        var actualMessage = result.Errors.First().Message;
+
+        // Assert
+        Assert.Equal(expectedMessage, actualMessage);
+    }
+
+    private void MockMapperSetup(int id)
+    {
+        _mockMapper.Setup(x => x
+            .Map<ImageDTO>(It.IsAny<Image>()))
+            .Returns(new ImageDTO { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsImage(int id)
+    {
+        _mockRepositoryWrapper.Setup(x => x.ImageRepository
+            .GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Image, bool>>>(),
+               It.IsAny<Func<IQueryable<Image>,
+               IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync(new Image { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ImageRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>,
+            IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync((IEnumerable<Image>?)null);
+    }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetAllVideosTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetAllVideosTest.cs
@@ -1,272 +1,271 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Video;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.Media.Video;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Media.Video.GetAll;
-using Streetcode.DAL.Entities.Media;
 using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.DAL.Entities.Media;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Video
+public class GetAllVideosHandlerTests
 {
-    public class GetAllVideosHandlerTests
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    public GetAllVideosHandlerTests()
     {
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
 
-        public GetAllVideosHandlerTests()
+    [Fact]
+    public async Task Handle_ReturnsOkResult_WithListOfVideos_WhenVideosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenVideosNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_LogsError_WhenVideosNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        _mockLogger.Verify(
+            logger => logger.LogError(
+                It.IsAny<GetAllVideosQuery>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCollectionOfCorrectCount_WhenVideosFound()
+    {
+        // Arrange
+        var mockVideo = GetVideoList();
+        var expectedCount = mockVideo.Count;
+
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+        var actualCount = result.Value.Count();
+
+        // Assert
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public async Task Handle_MapperShouldMapOnlyOnce_WhenVideosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper =>
+            mapper.Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable<Video>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnCollectionOfFactDto_WhenVideosFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<List<VideoDTO>>(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenVideosAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenVideosAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllVideosHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        var expectedError = "Cannot find any videos";
+
+        // Act
+        var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedError, result.Errors.First().Message);
+    }
+
+    private static List<Streetcode.DAL.Entities.Media.Video> GetVideoList()
+    {
+        return new List<Streetcode.DAL.Entities.Media.Video>
         {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsOkResult_WithListOfVideos_WhenVideosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenVideosNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_LogsError_WhenVideosNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            _mockLogger.Verify(
-                logger => logger.LogError(
-                    It.IsAny<GetAllVideosQuery>(),
-                    It.IsAny<string>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsCollectionOfCorrectCount_WhenVideosFound()
-        {
-            // Arrange
-            var mockVideo = GetVideoList();
-            var expectedCount = mockVideo.Count;
-
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-            var actualCount = result.Value.Count();
-
-            // Assert
-            Assert.Equal(expectedCount, actualCount);
-        }
-
-        [Fact]
-        public async Task Handle_MapperShouldMapOnlyOnce_WhenVideosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper =>
-                mapper.Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable< Streetcode.DAL.Entities.Media.Video>> ()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldReturnCollectionOfFactDto_WhenVideosFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<List<VideoDTO>>(result.Value);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenVideosAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenVideosAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllVideosHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            var expectedError = "Cannot find any videos";
-
-            // Act
-            var result = await handler.Handle(new GetAllVideosQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(expectedError, result.Errors.First().Message);
-        }
-
-        private static List<Streetcode.DAL.Entities.Media.Video> GetVideoList()
-        {
-            return new List<Streetcode.DAL.Entities.Media.Video>
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Title = "Video Title 1",
-                    Description = "Video Description 1",
-                    Url = "https://example.com/video1",
-                    StreetcodeId = 1,
-                },
-                new ()
-                {
-                    Id = 2,
-                    Title = "Video Title 2",
-                    Description = "Video Description 2",
-                    Url = "https://example.com/video2",
-                    StreetcodeId = 2,
-                },
-                new ()
-                {
-                    Id = 3,
-                    Title = "Video Title 3",
-                    Description = "Video Description 3",
-                    Url = "https://example.com/video3",
-                    StreetcodeId = 3,
-                },
-            };
-        }
-
-        private static List<VideoDTO> GetVideoDtoList()
-        {
-            return new List<VideoDTO>
+                Id = 1,
+                Title = "Video Title 1",
+                Description = "Video Description 1",
+                Url = "https://example.com/video1",
+                StreetcodeId = 1,
+            },
+            new ()
             {
-                new ()
-                {
-                   Id = 1,
-                   Description = "Video Description 1",
-                   Url = "https://example.com/video1",
-                },
-                new ()
-                {
-                   Id = 2,
-                   Description = "Video Description 2",
-                   Url = "https://example.com/video2",
-                },
-                new ()
-                {
-                   Id = 3,
-                   Description = "Video Description 3",
-                   Url = "https://example.com/video3",
-                },
-            };
-        }
+                Id = 2,
+                Title = "Video Title 2",
+                Description = "Video Description 2",
+                Url = "https://example.com/video2",
+                StreetcodeId = 2,
+            },
+            new ()
+            {
+                Id = 3,
+                Title = "Video Title 3",
+                Description = "Video Description 3",
+                Url = "https://example.com/video3",
+                StreetcodeId = 3,
+            },
+        };
+    }
 
-        private void MockMapperSetup()
+    private static List<VideoDTO> GetVideoDtoList()
+    {
+        return new List<VideoDTO>
         {
-            _mockMapper.Setup(x => x
-                .Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Video>>()))
-                .Returns(GetVideoDtoList());
-        }
+            new ()
+            {
+               Id = 1,
+               Description = "Video Description 1",
+               Url = "https://example.com/video1",
+            },
+            new ()
+            {
+               Id = 2,
+               Description = "Video Description 2",
+               Url = "https://example.com/video2",
+            },
+            new ()
+            {
+               Id = 3,
+               Description = "Video Description 3",
+               Url = "https://example.com/video3",
+            },
+        };
+    }
 
-        private void MockRepositorySetupReturnsData()
-        {
-            _mockRepositoryWrapper.Setup(x => x.VideoRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Video, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Video>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Video, object>>>()))
-                .ReturnsAsync(GetVideoList());
-        }
+    private void MockMapperSetup()
+    {
+        _mockMapper.Setup(x => x
+            .Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Video>>()))
+            .Returns(GetVideoDtoList());
+    }
 
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.VideoRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Video, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Video>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Video, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Video>?)null);
-        }
+    private void MockRepositorySetupReturnsData()
+    {
+        _mockRepositoryWrapper.Setup(x => x.VideoRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Video, bool>>>(),
+                It.IsAny<Func<IQueryable<Video>,
+            IIncludableQueryable<Video, object>>>()))
+            .ReturnsAsync(GetVideoList());
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.VideoRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Video, bool>>>(),
+                It.IsAny<Func<IQueryable<Video>,
+            IIncludableQueryable<Video, object>>>()))
+            .ReturnsAsync((IEnumerable<Video>?)null);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetVideoByIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetVideoByIdTest.cs
@@ -1,206 +1,202 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Video;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.Media.Video;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.MediatR.Media.Video.GetAll;
 using Streetcode.BLL.MediatR.Media.Video.GetById;
 using Streetcode.DAL.Entities.Media;
-using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Video
+public class GetVideoByIdTest
 {
-    public class GetVideoByIdTest
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+
+    public GetVideoByIdTest()
     {
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private readonly Mock<IMapper> _mockMapper;
-
-        public GetVideoByIdTest()
-        {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsVideo(id);
-            MockMapperSetup(id);
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenVideoExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsVideo(id);
-            MockMapperSetup(id);
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockRepositoryWrapper.Verify(
-                repo =>
-                repo.VideoRepository.GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Video, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Video>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Video, object>>>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_MapperCallMapOnlyOnce_WhenVideoExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsVideo(id);
-            MockMapperSetup(id);
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper => mapper.Map<VideoDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Video>()),
-                Times.Once);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsVideoWithCorrectId_WhenVideoExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsVideo(id);
-            MockMapperSetup(id);
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(id, result.Value.Id);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnVideoDto_WhenVideoExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsVideo(id);
-            MockMapperSetup(id);
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<VideoDTO>(result.Value);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnFail_WhenVideoIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenVideoIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetVideoByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            var expectedMessage = $"Cannot find a video with corresponding id: {id}";
-
-            // Act
-            var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
-            var actualMessage = result.Errors.First().Message;
-
-            // Assert
-            Assert.Equal(expectedMessage, actualMessage);
-        }
-
-        private void MockMapperSetup(int id)
-        {
-            _mockMapper.Setup(x => x
-                .Map<VideoDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Video>()))
-                .Returns(new VideoDTO { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsVideo(int id)
-        {
-            _mockRepositoryWrapper.Setup(x => x.VideoRepository
-                .GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Video, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Video>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Video, object>>>()))
-                .ReturnsAsync(new Streetcode.DAL.Entities.Media.Video { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.VideoRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Video, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Video>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Video, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Video>?)null);
-        }
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
     }
 
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsVideo(id);
+        MockMapperSetup(id);
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenVideoExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsVideo(id);
+        MockMapperSetup(id);
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(
+            repo =>
+            repo.VideoRepository.GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Video, bool>>>(),
+               It.IsAny<Func<IQueryable<Video>,
+               IIncludableQueryable<Video, object>>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_MapperCallMapOnlyOnce_WhenVideoExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsVideo(id);
+        MockMapperSetup(id);
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper => mapper.Map<VideoDTO>(It.IsAny<Video>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsVideoWithCorrectId_WhenVideoExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsVideo(id);
+        MockMapperSetup(id);
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(id, result.Value.Id);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnVideoDto_WhenVideoExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsVideo(id);
+        MockMapperSetup(id);
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<VideoDTO>(result.Value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnFail_WhenVideoIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenVideoIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetVideoByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        var expectedMessage = $"Cannot find a video with corresponding id: {id}";
+
+        // Act
+        var result = await handler.Handle(new GetVideoByIdQuery(id), CancellationToken.None);
+        var actualMessage = result.Errors.First().Message;
+
+        // Assert
+        Assert.Equal(expectedMessage, actualMessage);
+    }
+
+    private void MockMapperSetup(int id)
+    {
+        _mockMapper.Setup(x => x
+            .Map<VideoDTO>(It.IsAny<Video>()))
+            .Returns(new VideoDTO { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsVideo(int id)
+    {
+        _mockRepositoryWrapper.Setup(x => x.VideoRepository
+            .GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Video, bool>>>(),
+               It.IsAny<Func<IQueryable<Video>,
+               IIncludableQueryable<Video, object>>>()))
+            .ReturnsAsync(new Video { Id = id });
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.VideoRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Video, bool>>>(),
+                It.IsAny<Func<IQueryable<Video>,
+            IIncludableQueryable<Video, object>>>()))
+            .ReturnsAsync((IEnumerable<Video>?)null);
+    }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Fact/GetAllFactsTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Fact/GetAllFactsTests.cs
@@ -15,8 +15,8 @@ using Xunit;
 
 public class GetAllFactsTests
 {
-    private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-    private Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
     private readonly Mock<ILoggerService> _mockLogger;
 
     public GetAllFactsTests()

--- a/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
+++ b/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+    <CodeAnalysisRuleSet>../settings.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Streetcode/settings.ruleset
+++ b/Streetcode/settings.ruleset
@@ -1,287 +1,143 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="My Rules" Description="Description here." ToolsVersion="14.0">
+<RuleSet Name="My Rules" Description="Description here." ToolsVersion="17.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1027" Action="None" />
-    <!-- The code contains a tab or space character which is not consistent with the current project settings. -->
-    <Rule Id="SA1124" Action="Error" />
-    <!-- Regions must not be used -->
-    <Rule Id="SA1123" Action="Error" />
-    <!-- Regions must not be used within a code -->
-    <Rule Id="SA1652" Action="None" />
-    <!-- Enable XML output -->
-    <Rule Id="SA1309" Action="None" />
-    <!-- Field must not begin with an underscore -->
-    <Rule Id="SA1101" Action="None" />
-    <!-- Prefix local call with this -->
-    <Rule Id="SA1633" Action="None" />
-    <!-- Code header -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Using directive must appear within a namespace declaration -->
-    <Rule Id="SA1210" Action="None" />
-    <!-- Using directive must be ordered alphabetically by namespaces -->
-    <Rule Id="SA1305" Action="None" />
-    <!-- The name of a field or variable in C# uses Hungarian notation. -->
-    <Rule Id="SA1026" Action="Error" />
-    <!-- An implicitly typed array allocation within a C# code file is not spaced correctly. -->
-    <Rule Id="SA1412" Action="None" />
-    <!-- The encoding of the file is not UTF-8 with byte order mark. -->
-    <Rule Id="SA1413" Action="None" />
-    <!-- The last statement in a multi-line C# initializer or list is missing a trailing comma. -->
     <Rule Id="SA0001" Action="None" />
-    <!-- All diagnostics of XML documentation comments has been disabled due to the current project configuration. -->
-    <Rule Id="SA1118" Action="None" />
-    <!-- A parameter to a C# method or indexer, other than the first parameter, spans across multiple lines. -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- A static element is positioned beneath an instance element of the same type. -->
-    <Rule Id="SA1649" Action="Error" />
-    <!-- The file name of a C# code file does not match the first type declared in the file. For generics that are defined as Class1<T> the name of the file needs to be Class1{T}.cs or Class1`1.cs depending on the fileNamingConvention setting -->
-    <Rule Id="SA1117" Action="Error" />
-    <!-- The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line. -->
-    <Rule Id="SA1116" Action="Error" />
-    <!-- The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket. -->
-    <Rule Id="SA1005" Action="Error" />
-    <!-- A single-line comment within a C# code file does not begin with a single space. -->
-    <Rule Id="SA1515" Action="Error" />
-    <!-- A single-line comment within C# code is not preceded by a blank line. -->
-    <Rule Id="SA1513" Action="Error" />
-    <!-- A closing brace within a C# element, statement, or expression is not followed by a blank line. -->
-    <Rule Id="SA1202" Action="Error" />
-    <!-- An element within a C# code file is out of order within regard to access level, in relation to other elements in the code. -->
-    <Rule Id="SA1503" Action="Error" />
-    <!-- The opening and closing braces for a C# statement have been omitted. -->
-    <Rule Id="SA1127" Action="Error" />
-    <!-- A generic constraint on a type or method declaration is on the same line as the declaration, within a C# code file. -->
-    <Rule Id="SA1508" Action="Error" />
-    <!-- A closing brace within a C# element, statement, or expression is preceded by a blank line. -->
-    <Rule Id="SA1505" Action="Error" />
-    <!-- An opening brace within a C# element, statement, or expression is followed by a blank line. -->
-    <Rule Id="SA1203" Action="Error" />
-    <!-- A constant field is placed beneath a non-constant field. -->
-    <Rule Id="SA1208" Action="Error" />
-    <!-- Using directive for 'System' must appear before -->
     <Rule Id="SA1000" Action="None" />
-    <!-- The spacing around a C# keyword is incorrect. -->
-    <Rule Id="SA1201" Action="Error" />
-    <!-- An element within a C# code file is out of order in relation to the other elements in the code. -->
     <Rule Id="SA1001" Action="Error" />
-    <!-- The spacing around a comma is incorrect, within a C# code file. -->
-    <Rule Id="SA1021" Action="Error" />
-    <!-- A negative sign within a C# element is not spaced correctly. -->
-    <Rule Id="SA1022" Action="Error" />
-    <!-- A positive sign within a C# element is not spaced correctly. -->
-    <Rule Id="SA1100" Action="Error" />
-    <!-- A call to a member from an inherited class begins with base., and the local class does not contain an override or implementation of the member. -->
-    <Rule Id="SA1106" Action="Error" />
-    <!-- The C# code contains an extra semicolon. -->
-    <Rule Id="SA1111" Action="Error" />
-    <!-- The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is not placed on the same line as the last parameter. -->
-    <Rule Id="SA1112" Action="Error" />
-    <!-- The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is not placed on the same line as the opening bracket when the element does not take any parameters. -->
-    <Rule Id="SA1119" Action="Error" />
-    <!-- A C# statement contains parenthesis which are unnecessary and should be removed. -->
-    <Rule Id="SA1121" Action="Error" />
-    <!-- The code uses one of the basic C# types, but does not use the built-in alias for the type. -->
-    <Rule Id="SA1122" Action="None" />
-    <!-- The C# code includes an empty string, written as "". -->
-    <Rule Id="SA1133" Action="Error" />
-    <!-- Two or more attributes appeared within the same set of square brackets. -->
-    <Rule Id="SA1137" Action="Error" />
-    <!-- Two sibling elements which each start on their own line have different levels of indentation. -->
-    <Rule Id="SA1516" Action="None" />
-    <!-- Adjacent C# elements are not separated by a blank line. -->
-    <Rule Id="SA1300" Action="Error" />
-    <!-- The name of a C# element does not begin with an upper-case letter. -->
-    <Rule Id="SA1302" Action="Error" />
-    <!-- The name of a C# interface does not begin with the capital letter I. -->
-    <Rule Id="SA1303" Action="Error" />
-    <!-- The name of a constant C# field should begin with an upper-case letter. -->
-    <Rule Id="SA1304" Action="Error" />
-    <!-- The name of a non-private readonly C# field should being with an upper-case letter. -->
-    <Rule Id="SA1311" Action="Error" />
-    <!-- The name of a static readonly field does not begin with an upper-case letter. -->
-    <Rule Id="SA1400" Action="Error" />
-    <!-- The access modifier for a C# element has not been explicitly defined. -->
-    <Rule Id="SA1401" Action="Warning" />
-    <!-- A field within a C# class has an access modifier other than private. -->
-    <Rule Id="SA1402" Action="Error" />
-    <!-- A C# code file contains more than one unique type. -->
-    <Rule Id="SA1403" Action="Error" />
-    <!-- A C# code file contains more than one namespace. -->
-    <Rule Id="SA1404" Action="Error" />
-    <!-- A Code Analysis SuppressMessage attribute does not include a justification. -->
-    <Rule Id="SA1405" Action="Error" />
-    <!-- A call to Debug.Assert in C# code does not include a descriptive message. -->
-    <Rule Id="SA1406" Action="Error" />
-    <!-- A call to Debug.Fail in C# code does not include a descriptive message. -->
-    <Rule Id="SA1407" Action="Error" />
-    <!-- A C# statement contains a complex arithmetic expression which omits parenthesis around operators. -->
-    <Rule Id="SA1408" Action="Error" />
-    <!-- A C# statement contains a complex conditional expression which omits parenthesis around operators. -->
-    <Rule Id="SA1410" Action="Error" />
-    <!-- A call to a C# anonymous method does not contain any method parameters, yet the statement still includes parenthesis. -->
-    <Rule Id="SA1411" Action="Error" />
-    <!-- An attribute declaration does not contain any parameters, yet it still includes parenthesis. -->
-    <Rule Id="SA1600" Action="None" />
-    <!-- A C# code element is missing a documentation header. -->
-    <Rule Id="SA1601" Action="None" />
-    <!-- A C# partial element is missing a documentation header. -->
-    <Rule Id="SA1602" Action="None" />
-    <!-- An item within a C# enumeration is missing an Xml documentation header. -->
-    <Rule Id="SA1603" Action="Error" />
-    <!-- The Xml within a C# element's document header is badly formed. -->
-    <Rule Id="SA1609" Action="Warning" />
-    <!-- The Xml header documentation for a C# property does not contain a <value> tag. -->
-    <Rule Id="SA1636" Action="Error" />
-    <!-- The file header at the top of a C# code file does not contain the appropriate copyright text. -->
-    <Rule Id="SA1642" Action="Error" />
-    <!-- The XML documentation header for a C# constructor does not contain the appropriate summary text. -->
-    <Rule Id="SA1643" Action="Error" />
-    <!-- The Xml documentation header for a C# finalizer does not contain the appropriate summary text. -->
     <Rule Id="SA1002" Action="Error" />
-    <!-- The spacing around a semicolon is incorrect, within a C# code file. -->
     <Rule Id="SA1003" Action="Error" />
-    <!-- The spacing around an operator symbol is incorrect, within a C# code file. -->
     <Rule Id="SA1004" Action="Error" />
-    <!-- A line within a documentation header above a C# element does not begin with a single space. -->
+    <Rule Id="SA1005" Action="Error" />
     <Rule Id="SA1006" Action="Error" />
-    <!-- A C# preprocessor-type keyword is preceded by space. -->
     <Rule Id="SA1007" Action="Error" />
-    <!-- The operator keyword within a C# operator overload method is not followed by any whitespace. -->
     <Rule Id="SA1008" Action="Error" />
-    <!-- An opening parenthesis within a C# statement is not spaced correctly. -->
     <Rule Id="SA1010" Action="Error" />
-    <!-- An opening square bracket within a C# statement is not spaced correctly. -->
     <Rule Id="SA1011" Action="Error" />
-    <!-- A closing square bracket within a C# statement is not spaced correctly. -->
     <Rule Id="SA1012" Action="Error" />
-    <!-- An opening brace within a C# element is not spaced correctly. -->
     <Rule Id="SA1013" Action="Error" />
-    <!-- A closing brace within a C# element is not spaced correctly. -->
     <Rule Id="SA1014" Action="Error" />
-    <!-- An opening generic bracket within a C# element is not spaced correctly. -->
     <Rule Id="SA1015" Action="Error" />
-    <!-- A closing generic bracket within a C# element is not spaced correctly. -->
     <Rule Id="SA1016" Action="Error" />
-    <!-- An opening attribute bracket within a C# element is not spaced correctly. -->
     <Rule Id="SA1017" Action="Error" />
-    <!-- A closing attribute bracket within a C# element is not spaced correctly. -->
     <Rule Id="SA1018" Action="Error" />
-    <!-- A nullable type symbol within a C# element is not spaced correctly. -->
     <Rule Id="SA1019" Action="Error" />
-    <!-- The spacing around a member access symbol is incorrect, within a C# code file. -->
     <Rule Id="SA1020" Action="Error" />
-    <!-- An increment or decrement symbol within a C# element is not spaced correctly. -->
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
     <Rule Id="SA1023" Action="Error" />
-    <!-- A dereference symbol or an access-of symbol within a C# element is not spaced correctly. -->
     <Rule Id="SA1024" Action="Error" />
-    <!-- A colon within a C# element is not spaced correctly. -->
     <Rule Id="SA1025" Action="Error" />
-    <!-- The code contains multiple whitespace characters in a row. -->
+    <Rule Id="SA1026" Action="Error" />
+    <Rule Id="SA1027" Action="None" />
     <Rule Id="SA1028" Action="Error" />
-    <!-- A line of code ends with a space, tab, or other whitespace characters before the end of line character(s). -->
+    <Rule Id="SA1100" Action="Error" />
+    <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1102" Action="Error" />
-    <!-- A C# query clause does not begin on the same line as the previous clause, or on the next line. -->
     <Rule Id="SA1103" Action="Error" />
-    <!-- The clauses within a C# query expression are not all placed on the same line, and each clause is not placed on its own line. -->
     <Rule Id="SA1104" Action="Error" />
-    <!-- A clause within a C# query expression begins on the same line as the previous clause, when the previous clause spans across multiple lines. -->
     <Rule Id="SA1105" Action="Error" />
-    <!-- A clause within a C# query expression spans across multiple lines, and does not begin on its own line. -->
+    <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1107" Action="Error" />
-    <!-- The C# code contains more than one statement on a single line. -->
     <Rule Id="SA1108" Action="Error" />
-    <!-- A C# statement contains a comment between the declaration of the statement and the opening brace of the statement. -->
     <Rule Id="SA1109" Action="Error" />
-    <!-- A C# statement contains a region tag between the declaration of the statement and the opening brace of the statement. -->
     <Rule Id="SA1110" Action="Error" />
-    <!-- The opening parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or indexer, is not placed on the same line as the method or indexer name. -->
+    <Rule Id="SA1111" Action="Error" />
+    <Rule Id="SA1112" Action="Error" />
     <Rule Id="SA1113" Action="Error" />
-    <!-- A comma between two parameters in a call to a C# method or indexer, or in the declaration of a method or indexer, is not placed on the same line as the previous parameter. -->
     <Rule Id="SA1114" Action="Error" />
-    <!-- The start of the parameter list for a method or indexer call or declaration does not begin on the same line as the opening bracket, or on the line after the opening bracket. -->
     <Rule Id="SA1115" Action="Error" />
-    <!-- A parameter within a C# method or indexer call or declaration does not begin on the same line as the previous parameter, or on the next line. -->
+    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1117" Action="Error" />
+    <Rule Id="SA1118" Action="None" />
+    <Rule Id="SA1119" Action="Error" />
     <Rule Id="SA1120" Action="Error" />
-    <!-- The C# comment does not contain any comment text. -->
+    <Rule Id="SA1121" Action="Error" />
+    <Rule Id="SA1122" Action="None" />
+    <Rule Id="SA1123" Action="Error" />
+    <Rule Id="SA1124" Action="Error" />
     <Rule Id="SA1126" Action="Error" />
-    <!-- A call to a member is not prefixed with the 'this.', 'base.', 'object.' or 'typename.' prefix to indicate the intended method call, within a C# code file. -->
+    <Rule Id="SA1127" Action="Error" />
+    <Rule Id="SA1133" Action="Error" />
+    <Rule Id="SA1137" Action="Error" />
+    <Rule Id="SA1200" Action="None" />
+    <Rule Id="SA1201" Action="Error" />
+    <Rule Id="SA1202" Action="Error" />
+    <Rule Id="SA1203" Action="Error" />
+    <Rule Id="SA1204" Action="None" />
     <Rule Id="SA1205" Action="Error" />
-    <!-- The partial element does not have an access modifier defined. -->
     <Rule Id="SA1206" Action="Error" />
-    <!-- The keywords within the declaration of an element do not follow a standard ordering scheme. -->
     <Rule Id="SA1207" Action="Error" />
-    <!-- The keyword protected is positioned after the keyword internal within the declaration of a protected internal C# element, or the keyword private is positioned after the keyword protected. -->
+    <Rule Id="SA1208" Action="Error" />
+    <Rule Id="SA1210" Action="None" />
+    <Rule Id="SA1300" Action="Error" />
+    <Rule Id="SA1302" Action="Error" />
+    <Rule Id="SA1303" Action="Error" />
+    <Rule Id="SA1304" Action="Error" />
     <Rule Id="SA1306" Action="Error" />
-    <!-- The name of a field in C# does not begin with a lower-case letter. -->
     <Rule Id="SA1307" Action="Error" />
-    <!-- The name of a public or internal field in C# does not begin with an upper-case letter. -->
+    <Rule Id="SA1309" Action="None" />
     <Rule Id="SA1310" Action="Error" />
-    <!-- A field name in C# contains an underscore. -->
+    <Rule Id="SA1311" Action="Error" />
     <Rule Id="SA1312" Action="Error" />
-    <!-- The name of a variable in C# does not begin with a lower-case letter. -->
     <Rule Id="SA1313" Action="None" />
-    <!-- The name of a parameter in C# does not begin with a lower-case letter. -->
+    <Rule Id="SA1400" Action="Error" />
+    <Rule Id="SA1402" Action="Error" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
+    <Rule Id="SA1405" Action="Error" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1409" Action="Error" />
-    <!-- A C# file contains code which is unnecessary and can be removed without changing the overall logic of the code. -->
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
+    <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1500" Action="Error" />
-    <!-- The opening or closing brace within a C# statement, element, or expression is not placed on its own line. -->
     <Rule Id="SA1501" Action="Error" />
-    <!-- A C# statement containing opening and closing braces is written completely on a single line. -->
     <Rule Id="SA1502" Action="Error" />
-    <!-- A C# element containing opening and closing braces is written completely on a single line. -->
+    <Rule Id="SA1503" Action="Error" />
     <Rule Id="SA1504" Action="Error" />
-    <!-- Within a C# property, indexer or event, at least one of the child accessors is written on a single line, and at least one of the child accessors is written across multiple lines. -->
+    <Rule Id="SA1505" Action="Error" />
     <Rule Id="SA1506" Action="Error" />
-    <!-- An element documentation header above a C# element is followed by a blank line. -->
     <Rule Id="SA1507" Action="Error" />
-    <!-- The C# code contains multiple blank lines in a row. -->
+    <Rule Id="SA1508" Action="Error" />
     <Rule Id="SA1509" Action="Error" />
-    <!-- An opening brace within a C# element, statement, or expression is preceded by a blank line. -->
     <Rule Id="SA1510" Action="Error" />
-    <!-- Chained C# statements are separated by a blank line. -->
     <Rule Id="SA1511" Action="Error" />
-    <!-- The while footer at the bottom of a do-while statement is separated from the statement by a blank line. -->
     <Rule Id="SA1512" Action="None" />
-    <!-- A single-line comment within C# code is followed by a blank line. -->
+    <Rule Id="SA1513" Action="Error" />
     <Rule Id="SA1514" Action="Error" />
-    <!-- An element documentation header above a C# element is not preceded by a blank line. -->
+    <Rule Id="SA1515" Action="Error" />
+    <Rule Id="SA1516" Action="None" />
     <Rule Id="SA1517" Action="Error" />
-    <!-- The code file has blank lines at the start. -->
     <Rule Id="SA1518" Action="Error" />
-    <!-- The line endings at the end of a file do not match the settings for the project. -->
     <Rule Id="SA1519" Action="Error" />
-    <!-- The opening and closing braces for a multi-line C# statement have been omitted. -->
     <Rule Id="SA1520" Action="Error" />
-    <!-- The opening and closing braces of a chained if/else if/else construct were included for some clauses, but omitted for others. -->
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1603" Action="Error" />
     <Rule Id="SA1604" Action="Error" />
-    <!-- The Xml header documentation for a C# element is missing a <summary> tag. -->
     <Rule Id="SA1608" Action="Error" />
-    <!-- The <summary> tag within an element's Xml header documentation contains the default text generated by Visual Studio during the creation of the element. -->
+    <Rule Id="SA1609" Action="Warning" />
     <Rule Id="SA1610" Action="Error" />
-    <!-- The Xml header documentation for a C# property contains an empty <value> tag. -->
     <Rule Id="SA1612" Action="Error" />
-    <!-- The documentation describing the parameters to a C# method, constructor, delegate or indexer element does not match the actual parameters on the element. -->
     <Rule Id="SA1613" Action="Error" />
-    <!-- A <param> tag within a C# element's documentation header is missing a name attribute containing the name of the parameter. -->
     <Rule Id="SA1614" Action="Error" />
-    <!-- A <param> tag within a C# element's documentation header is empty. -->
     <Rule Id="SA1615" Action="Error" />
-    <!-- A C# element is missing documentation for its return value. -->
     <Rule Id="SA1616" Action="Error" />
-    <!-- The <returns> tag within a C# element's documentation header is empty. -->
     <Rule Id="SA1617" Action="Error" />
-    <!-- A C# code element does not contain a return value, or returns void, but the documentation header for the element contains a <returns> tag. -->
     <Rule Id="SA1625" Action="Error" />
-    <!-- The Xml documentation for a C# element contains two or more identical entries, indicating that the documentation has been copied and pasted. This can sometimes indicate invalid or poorly written documentation. -->
     <Rule Id="SA1626" Action="Error" />
-    <!-- The C# code contains a single-line comment which begins with three forward slashes in a row. -->
     <Rule Id="SA1627" Action="Error" />
-    <!-- The Xml header documentation for a C# code element contains an empty tag. -->
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
     <Rule Id="SA1644" Action="Error" />
-    <!-- A section within the Xml documentation header for a C# element contains blank lines. -->
+    <Rule Id="SA1649" Action="None" />
+    <Rule Id="SA1652" Action="None" />
     <Rule Id="SX1101" Action="Error" />
-    <!-- A call to an instance member of the local class or a base class is prefixed with this.. -->
     <Rule Id="SX1309" Action="Error" />
-    <!-- A field name does not begin with an underscore. -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Resolve StyleCop analyser warnings And bring the test code to these requirements.

I decided not to change settings.ruleset for now. It’s better to collect more information about which rules bother you the most when working on code.
However, I added the currently active settings.ruleset to the Streetcode.XUnitTest project to significantly reduce the number of warnings about code non-compliance with the rules.
In addition, I edited the project files Streetcode.BLL and Streetcode.WebApi - removed unnecessary lines and aligned the text