### PR TITLE
Resolve StyleCop analyser warnings for tests - GetAllArtTest, GetArtByIdTest, GetAllAudioHandlerTests, GetAudioByIdHandlerTests and GetAllVideosTest

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetAllArtTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetAllArtTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Art;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
@@ -11,270 +13,267 @@ using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Art
+public class GetAllArtTest
 {
-    public class GetAllArtTest
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    public GetAllArtTest()
     {
-        private Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private Mock<IMapper> _mockMapper;
-        private readonly Mock<ILoggerService> _mockLogger;
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
 
-        public GetAllArtTest()
+    [Fact]
+    public async Task Handle_ReturnsOkResult_WithListOfArts_WhenArtFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenArtsNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_LogsError_WhenArtNotFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        _mockLogger.Verify(
+            logger => logger.LogError(
+                It.IsAny<GetAllArtsQuery>(),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCollectionOfCorrectCount_WhenArtsFound()
+    {
+        // Arrange
+        var mockVideo = GetArtList();
+        var expectedCount = mockVideo.Count;
+
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+        var actualCount = result.Value.Count();
+
+        // Assert
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public async Task Handle_MapperShouldMapOnlyOnce_WhenArtsFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        _mockMapper.Verify(
+            mapper =>
+            mapper.Map<IEnumerable<ArtDTO>>(It.IsAny<IEnumerable<Art>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnCollectionOfArtDto_WhenArtsFound()
+    {
+        // Arrange
+        MockRepositorySetupReturnsData();
+        MockMapperSetup();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.IsType<List<ArtDTO>>(result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailedResult_WhenArtsAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenArtsAreNull()
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
+
+        var handler = new GetAllArtsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+
+        var expectedError = "Cannot find any arts";
+
+        // Act
+        var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedError, result.Errors.First().Message);
+    }
+
+    private static List<Art> GetArtList()
+    {
+        return new List<Art>
         {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsOkResult_WithListOfArts_WhenArtFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenArtsNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_LogsError_WhenArtNotFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            _mockLogger.Verify(
-                logger => logger.LogError(
-                    It.IsAny<GetAllArtsQuery>(),
-                    It.IsAny<string>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsCollectionOfCorrectCount_WhenArtsFound()
-        {
-            // Arrange
-            var mockVideo = GetArtList();
-            var expectedCount = mockVideo.Count;
-
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-            var actualCount = result.Value.Count();
-
-            // Assert
-            Assert.Equal(expectedCount, actualCount);
-        }
-
-        [Fact]
-        public async Task Handle_MapperShouldMapOnlyOnce_WhenArtsFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            _mockMapper.Verify(
-                mapper =>
-                mapper.Map<IEnumerable<ArtDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Images.Art>>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldReturnCollectionOfArtDto_WhenArtsFound()
-        {
-            // Arrange
-            MockRepositorySetupReturnsData();
-            MockMapperSetup();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.IsType<List<ArtDTO>>(result.Value);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailedResult_WhenArtsAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.True(result.IsFailed);
-        }
-
-        [Fact]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenArtsAreNull()
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
-
-            var handler = new GetAllArtsHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
-
-            var expectedError = "Cannot find any arts";
-
-            // Act
-            var result = await handler.Handle(new GetAllArtsQuery(), CancellationToken.None);
-
-            // Assert
-            Assert.Equal(expectedError, result.Errors.First().Message);
-        }
-
-        private static List<Streetcode.DAL.Entities.Media.Images.Art> GetArtList()
-        {
-            return new List<Streetcode.DAL.Entities.Media.Images.Art>
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Title = "Art Title 1",
-                    Description = "Art Description 1",
-                    ImageId = 1,
-                    StreetcodeArts = new List<StreetcodeArt>(),
-                },
-                new ()
-                {
-                    Id = 2,
-                    Title = "Art Title 2",
-                    Description = "Art Description 2",
-                    ImageId = 2,
-                    StreetcodeArts = new List<StreetcodeArt>(),
-                },
-                new ()
-                {
-                    Id = 3,
-                    Title = "Art Title 3",
-                    Description = "Art Description 3",
-                    ImageId = 3,
-                    StreetcodeArts = new List<StreetcodeArt>(),
-                },
-            };
-        }
-
-        private static List<ArtDTO> GetArtDtoList()
-        {
-            return new List<ArtDTO>
+                Id = 1,
+                Title = "Art Title 1",
+                Description = "Art Description 1",
+                ImageId = 1,
+                StreetcodeArts = new List<StreetcodeArt>(),
+            },
+            new ()
             {
-                new ()
-                {
-                    Id = 1,
-                    Title = "Art Title 1",
-                    Description = "Art Description 1",
-                    ImageId = 1,
-                    Image = new ImageDTO(),
-                },
-                new ()
-                {
-                    Id = 2,
-                    Title = "Art Title 2",
-                    Description = "Art Description 2",
-                    ImageId = 2,
-                    Image = new ImageDTO(),
-                },
-                new ()
-                {
-                    Id = 3,
-                    Title = "Art Title 3",
-                    Description = "Art Description 3",
-                    ImageId = 3,
-                    Image = new ImageDTO(),
-                },
-            };
-        }
+                Id = 2,
+                Title = "Art Title 2",
+                Description = "Art Description 2",
+                ImageId = 2,
+                StreetcodeArts = new List<StreetcodeArt>(),
+            },
+            new ()
+            {
+                Id = 3,
+                Title = "Art Title 3",
+                Description = "Art Description 3",
+                ImageId = 3,
+                StreetcodeArts = new List<StreetcodeArt>(),
+            },
+        };
+    }
 
-        private void MockMapperSetup()
+    private static List<ArtDTO> GetArtDtoList()
+    {
+        return new List<ArtDTO>
         {
-            _mockMapper.Setup(x => x
-                .Map<IEnumerable<ArtDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Images.Art>>()))
-                .Returns(GetArtDtoList());
-        }
+            new ()
+            {
+                Id = 1,
+                Title = "Art Title 1",
+                Description = "Art Description 1",
+                ImageId = 1,
+                Image = new ImageDTO(),
+            },
+            new ()
+            {
+                Id = 2,
+                Title = "Art Title 2",
+                Description = "Art Description 2",
+                ImageId = 2,
+                Image = new ImageDTO(),
+            },
+            new ()
+            {
+                Id = 3,
+                Title = "Art Title 3",
+                Description = "Art Description 3",
+                ImageId = 3,
+                Image = new ImageDTO(),
+            },
+        };
+    }
 
-        private void MockRepositorySetupReturnsData()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ArtRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Art, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Art>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Art, object>>>()))
-                .ReturnsAsync(GetArtList());
-        }
+    private void MockMapperSetup()
+    {
+        _mockMapper.Setup(x => x
+            .Map<IEnumerable<ArtDTO>>(It.IsAny<IEnumerable<Art>>()))
+            .Returns(GetArtDtoList());
+    }
 
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ArtRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Art, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Art>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Art, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Images.Art>?)null);
-        }
+    private void MockRepositorySetupReturnsData()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ArtRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>,
+            IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync(GetArtList());
+    }
+
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ArtRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>,
+            IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync((IEnumerable<Art>?)null);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetArtByIdTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/GetArtByIdTest.cs
@@ -1,206 +1,202 @@
-﻿using System.Linq.Expressions;
+﻿namespace Streetcode.XUnitTest.MediatRTests.Media.Art;
+
+using System.Linq.Expressions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.Media.Art;
-using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.MediatR.Media.Art.GetAll;
 using Streetcode.BLL.MediatR.Media.Art.GetById;
 using Streetcode.DAL.Entities.Media.Images;
-using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
-namespace Streetcode.XUnitTest.MediatRTests.Media.Art
+public class GetArtByIdTest
 {
-    public class GetArtByIdTest
+    private readonly Mock<ILoggerService> _mockLogger;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+
+    public GetArtByIdTest()
     {
-        private readonly Mock<ILoggerService> _mockLogger;
-        private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-        private readonly Mock<IMapper> _mockMapper;
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
 
-        public GetArtByIdTest()
-        {
-            _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-            _mockMapper = new Mock<IMapper>();
-            _mockLogger = new Mock<ILoggerService>();
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsArt(id);
+        MockMapperSetup(id);
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsOkResult_WhenIdExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsArt(id);
-            MockMapperSetup(id);
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
 
-            // Assert
-            Assert.True(result.IsSuccess);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenArtExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsArt(id);
+        MockMapperSetup(id);
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_RepositoryCallGetFirstOrDefaultAsyncOnlyOnce_WhenArtExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsArt(id);
-            MockMapperSetup(id);
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        _mockRepositoryWrapper.Verify(
+            repo =>
+            repo.ArtRepository.GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Art, bool>>>(),
+               It.IsAny<Func<IQueryable<Art>,
+               IIncludableQueryable<Art, object>>>()),
+            Times.Once);
+    }
 
-            // Assert
-            _mockRepositoryWrapper.Verify(
-                repo =>
-                repo.ArtRepository.GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Art, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Art>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Art, object>>>()),
-                Times.Once);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_MapperCallMapOnlyOnce_WhenArtExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsArt(id);
+        MockMapperSetup(id);
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_MapperCallMapOnlyOnce_WhenArtExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsArt(id);
-            MockMapperSetup(id);
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        _mockMapper.Verify(
+            mapper => mapper.Map<ArtDTO>(It.IsAny<Art>()),
+            Times.Once);
+    }
 
-            // Assert
-            _mockMapper.Verify(
-                mapper => mapper.Map<ArtDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Images.Art>()),
-                Times.Once);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnsArtWithCorrectId_WhenArtExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsArt(id);
+        MockMapperSetup(id);
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnsArtWithCorrectId_WhenArtExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsArt(id);
-            MockMapperSetup(id);
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        Assert.Equal(id, result.Value.Id);
+    }
 
-            // Assert
-            Assert.Equal(id, result.Value.Id);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnArtDto_WhenArtExists(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsArt(id);
+        MockMapperSetup(id);
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnArtDto_WhenArtExists(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsArt(id);
-            MockMapperSetup(id);
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        Assert.IsType<ArtDTO>(result.Value);
+    }
 
-            // Assert
-            Assert.IsType<ArtDTO>(result.Value);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ReturnFail_WhenArtIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ReturnFail_WhenArtIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        // Assert
+        Assert.True(result.IsFailed);
+    }
 
-            // Assert
-            Assert.True(result.IsFailed);
-        }
+    [Theory]
+    [InlineData(1)]
+    public async Task Handle_ShouldLogCorrectErrorMessage_WhenArtIsNotFound(int id)
+    {
+        // Arrange
+        MockRepositorySetupReturnsNull();
 
-        [Theory]
-        [InlineData(1)]
-        public async Task Handle_ShouldLogCorrectErrorMessage_WhenArtIsNotFound(int id)
-        {
-            // Arrange
-            MockRepositorySetupReturnsNull();
+        var handler = new GetArtByIdHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
 
-            var handler = new GetArtByIdHandler(
-                _mockRepositoryWrapper.Object,
-                _mockMapper.Object,
-                _mockLogger.Object);
+        var expectedMessage = $"Cannot find an art with corresponding id: {id}";
 
-            var expectedMessage = $"Cannot find an art with corresponding id: {id}";
+        // Act
+        var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
+        var actualMessage = result.Errors.First().Message;
 
-            // Act
-            var result = await handler.Handle(new GetArtByIdQuery(id), CancellationToken.None);
-            var actualMessage = result.Errors.First().Message;
+        // Assert
+        Assert.Equal(expectedMessage, actualMessage);
+    }
 
-            // Assert
-            Assert.Equal(expectedMessage, actualMessage);
-        }
+    private void MockMapperSetup(int id)
+    {
+        _mockMapper.Setup(x => x
+            .Map<ArtDTO>(It.IsAny<Art>()))
+            .Returns(new ArtDTO { Id = id });
+    }
 
-        private void MockMapperSetup(int id)
-        {
-            _mockMapper.Setup(x => x
-                .Map<ArtDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Images.Art>()))
-                .Returns(new ArtDTO { Id = id });
-        }
+    private void MockRepositorySetupReturnsArt(int id)
+    {
+        _mockRepositoryWrapper.Setup(x => x.ArtRepository
+            .GetFirstOrDefaultAsync(
+               It.IsAny<Expression<Func<Art, bool>>>(),
+               It.IsAny<Func<IQueryable<Art>,
+               IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync(new Art { Id = id });
+    }
 
-        private void MockRepositorySetupReturnsArt(int id)
-        {
-            _mockRepositoryWrapper.Setup(x => x.ArtRepository
-                .GetFirstOrDefaultAsync(
-                   It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Art, bool>>>(),
-                   It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Art>,
-                   IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Art, object>>>()))
-                .ReturnsAsync(new Streetcode.DAL.Entities.Media.Images.Art { Id = id });
-        }
-
-        private void MockRepositorySetupReturnsNull()
-        {
-            _mockRepositoryWrapper.Setup(x => x.ArtRepository
-                .GetAllAsync(
-                    It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Images.Art, bool>>>(),
-                    It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Images.Art>,
-                IIncludableQueryable<Streetcode.DAL.Entities.Media.Images.Art, object>>>()))
-                .ReturnsAsync((IEnumerable<Streetcode.DAL.Entities.Media.Images.Art>?)null);
-        }
+    private void MockRepositorySetupReturnsNull()
+    {
+        _mockRepositoryWrapper.Setup(x => x.ArtRepository
+            .GetAllAsync(
+                It.IsAny<Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>,
+            IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync((IEnumerable<Art>?)null);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAllAudioHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAllAudioHandlerTests.cs
@@ -197,9 +197,9 @@ public class GetAllAudioHandlerTests
         Assert.Equal(expectedError, result.Errors.First().Message);
     }
 
-    private static List<Streetcode.DAL.Entities.Media.Audio> GetAudioList()
+    private static List<Audio> GetAudioList()
     {
-        return new List<Streetcode.DAL.Entities.Media.Audio>
+        return new List<Audio>
         {
             new ()
             {
@@ -262,7 +262,7 @@ public class GetAllAudioHandlerTests
     private void MockMapperSetup()
     {
         _mockMapper.Setup(x => x
-            .Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Audio>>()))
+            .Map<IEnumerable<AudioDTO>>(It.IsAny<IEnumerable<Audio>>()))
             .Returns(GetAudioDtoList());
     }
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAudioByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Audio/GetAudioByIdHandlerTests.cs
@@ -69,9 +69,9 @@ public class GetAudioByIdHandlerTests
         _mockRepositoryWrapper.Verify(
             repo =>
             repo.AudioRepository.GetFirstOrDefaultAsync(
-               It.IsAny<Expression<Func<Streetcode.DAL.Entities.Media.Audio, bool>>>(),
-               It.IsAny<Func<IQueryable<Streetcode.DAL.Entities.Media.Audio>,
-               IIncludableQueryable<Streetcode.DAL.Entities.Media.Audio, object>>>()),
+               It.IsAny<Expression<Func<Audio, bool>>>(),
+               It.IsAny<Func<IQueryable<Audio>,
+               IIncludableQueryable<Audio, object>>>()),
             Times.Once);
     }
 
@@ -186,7 +186,7 @@ public class GetAudioByIdHandlerTests
     private void MockMapperSetup(int id)
     {
         _mockMapper.Setup(x => x
-            .Map<AudioDTO>(It.IsAny<Streetcode.DAL.Entities.Media.Audio>()))
+            .Map<AudioDTO>(It.IsAny<Audio>()))
             .Returns(new AudioDTO { Id = id });
     }
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetAllVideosTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Video/GetAllVideosTest.cs
@@ -186,9 +186,9 @@ public class GetAllVideosHandlerTests
         Assert.Equal(expectedError, result.Errors.First().Message);
     }
 
-    private static List<Streetcode.DAL.Entities.Media.Video> GetVideoList()
+    private static List<Video> GetVideoList()
     {
-        return new List<Streetcode.DAL.Entities.Media.Video>
+        return new List<Video>
         {
             new ()
             {
@@ -245,7 +245,7 @@ public class GetAllVideosHandlerTests
     private void MockMapperSetup()
     {
         _mockMapper.Setup(x => x
-            .Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable<Streetcode.DAL.Entities.Media.Video>>()))
+            .Map<IEnumerable<VideoDTO>>(It.IsAny<IEnumerable<Video>>()))
             .Returns(GetVideoDtoList());
     }
 


### PR DESCRIPTION
Resolve StyleCop analyser warnings for tests - GetAllArtTest, GetArtByIdTest, GetAllAudioHandlerTests, GetAudioByIdHandlerTests and GetAllVideosTest.

Make this changes.

GetAllArtTest: SA1214 (A readonly field is positioned beneath a non-readonly field) and IDE0001 (name can be simplified)
GetArtByIdTest: IDE0001 (name can be simplified)
GetAllAudioHandlerTests: IDE0001 (name can be simplified)
GetAudioByIdHandlerTests: IDE0001 (name can be simplified)
GetAllVideosTest: IDE0001 (name can be simplified)