### PR TITLE
Fix access modifier for resource files

### DIFF
--- a/Streetcode/Streetcode.BLL/Resources/Errors/CannotCreateEntityErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/CannotCreateEntityErrors.Designer.cs
@@ -22,7 +22,7 @@ namespace Streetcode.BLL.Resources.Errors {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class CannotCreateEntityErrors {
+    public class CannotCreateEntityErrors {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Streetcode.BLL.Resources.Errors {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Streetcode.BLL.Resources.Errors.CannotCreateEntityErrors", typeof(CannotCreateEntityErrors).Assembly);
@@ -51,7 +51,7 @@ namespace Streetcode.BLL.Resources.Errors {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Streetcode.BLL.Resources.Errors {
         /// <summary>
         ///   Looks up a localized string similar to Cannot create a fact.
         /// </summary>
-        internal static string CannotCreateFact {
+        public static string CannotCreateFact {
             get {
                 return ResourceManager.GetString("CannotCreateFact", resourceCulture);
             }


### PR DESCRIPTION
Fix access modifier for resource files:
- CreateFactErrors.resx
- ReorderFactErrors.resx
- CannotCreateEntityErrors.resx
- CannotFindEntityErrors.resx
- CannotUpdateEntityErrors.resx