### PR TITLE
Change Error messages in ReorderFactHandler

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
@@ -33,7 +33,7 @@ public sealed class ReorderFactHandler : IRequestHandler<ReorderFactCommand, Res
 
         if (factsCount == 0)
         {
-            return CannotFindFactByStreetcodeId(request);
+            return CannotFindFactsWithStreetcodeId(request);
         }
 
         if (request.ReorderedIdArr.Length != factsCount)
@@ -72,9 +72,11 @@ public sealed class ReorderFactHandler : IRequestHandler<ReorderFactCommand, Res
         return Result.Fail(errorMsg);
     }
 
-    private Result<ReorderFactResponseDto> CannotFindFactByStreetcodeId(ReorderFactRequestDto request)
+    private Result<ReorderFactResponseDto> CannotFindFactsWithStreetcodeId(ReorderFactRequestDto request)
     {
-        var errorMsg = string.Format(Resources.Errors.CannotFindEntityErrors.CannotFindFactByStreetcodeId, request.StreetcodeId);
+        var errorMsg = string.Format(
+            Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.ThereAreNoFactsWithCorrespondingStreetcodeId,
+            request.StreetcodeId);
         _logger.LogError(request, errorMsg);
         return Result.Fail(errorMsg);
     }
@@ -92,14 +94,17 @@ public sealed class ReorderFactHandler : IRequestHandler<ReorderFactCommand, Res
 
     private Result<ReorderFactResponseDto> IncorrectFactIdTransferredInArray(ReorderFactRequestDto request, int id)
     {
-        var errorMsg = string.Format(Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.IncorrectFactIdTransferredInArray, id, request.StreetcodeId);
+        var errorMsg = string.Format(
+            Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.IncorrectFactIdTransferredInArray,
+            id,
+            request.StreetcodeId);
         _logger.LogError(request, errorMsg);
         return Result.Fail(errorMsg);
     }
 
     private Result<ReorderFactResponseDto> CannotUpdateFactsAfterReordering(ReorderFactRequestDto request)
     {
-        var errorMsg = string.Format(Resources.Errors.CannotUpdateEntityErrors.CannotUpdateNumberInFact);
+        var errorMsg = string.Format(Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.CannotUpdateNumberInFact);
         _logger.LogError(request, errorMsg);
         return Result.Fail(errorMsg);
     }

--- a/Streetcode/Streetcode.BLL/Resources/Errors/CannotFindEntityErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/CannotFindEntityErrors.Designer.cs
@@ -61,15 +61,6 @@ namespace Streetcode.BLL.Resources.Errors {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find facts with corresponding StreetcodeId: {0}.
-        /// </summary>
-        public static string CannotFindFactByStreetcodeId {
-            get {
-                return ResourceManager.GetString("CannotFindFactByStreetcodeId", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot find an image with corresponding id: {0}.
         /// </summary>
         public static string CannotFindImageById {

--- a/Streetcode/Streetcode.BLL/Resources/Errors/CannotFindEntityErrors.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/CannotFindEntityErrors.resx
@@ -117,10 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CannotFindFactByStreetcodeId" xml:space="preserve">
-    <value>Cannot find facts with corresponding StreetcodeId: {0}</value>
-    <comment>format argument 0 - streetcode id</comment>
-  </data>
   <data name="CannotFindImageById" xml:space="preserve">
     <value>Cannot find an image with corresponding id: {0}</value>
     <comment>format argument 0 - image id</comment>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/CannotUpdateEntityErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/CannotUpdateEntityErrors.Designer.cs
@@ -68,14 +68,5 @@ namespace Streetcode.BLL.Resources.Errors {
                 return ResourceManager.GetString("CannotUpdateFact", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot update property Number in fact.
-        /// </summary>
-        public static string CannotUpdateNumberInFact {
-            get {
-                return ResourceManager.GetString("CannotUpdateNumberInFact", resourceCulture);
-            }
-        }
     }
 }

--- a/Streetcode/Streetcode.BLL/Resources/Errors/CannotUpdateEntityErrors.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/CannotUpdateEntityErrors.resx
@@ -121,7 +121,4 @@
     <value>Cannot update fact with corresponding id: {0}</value>
     <comment>format argument 0 - fact id</comment>
   </data>
-  <data name="CannotUpdateNumberInFact" xml:space="preserve">
-    <value>Cannot update property Number in fact</value>
-  </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
@@ -61,7 +61,16 @@ namespace Streetcode.BLL.Resources.Errors.ValidationErrors.Fact {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The incoming array with Ids is null or contain no strings.
+        ///   Looks up a localized string similar to Cannot update property Number in fact.
+        /// </summary>
+        public static string CannotUpdateNumberInFact {
+            get {
+                return ResourceManager.GetString("CannotUpdateNumberInFact", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The incoming array of Ids is null or has no elements..
         /// </summary>
         public static string IncomingFactIdArrIsNullOrEmpty {
             get {
@@ -84,6 +93,15 @@ namespace Streetcode.BLL.Resources.Errors.ValidationErrors.Fact {
         public static string IncorrectIdsNumberInArray {
             get {
                 return ResourceManager.GetString("IncorrectIdsNumberInArray", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There are no facts with corresponding StreetcodeId = {0}.
+        /// </summary>
+        public static string ThereAreNoFactsWithCorrespondingStreetcodeId {
+            get {
+                return ResourceManager.GetString("ThereAreNoFactsWithCorrespondingStreetcodeId", resourceCulture);
             }
         }
     }

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotUpdateNumberInFact" xml:space="preserve">
+    <value>Cannot update property Number in fact</value>
+  </data>
   <data name="IncomingFactIdArrIsNullOrEmpty" xml:space="preserve">
-    <value>The incoming array with Ids is null or contain no strings</value>
+    <value>The incoming array of Ids is null or has no elements.</value>
   </data>
   <data name="IncorrectFactIdTransferredInArray" xml:space="preserve">
     <value>Fact with Id={0} does not exist or has StreetcodeId different from {1}</value>
@@ -132,5 +135,9 @@ argument 1 - streetcode id</comment>
 argument 0 - number of IDs transferred in the array
 argument 1 - number of facts for the StreetcodeContent with a certain StreetcodeId
 argument 2 - StreetcodeId</comment>
+  </data>
+  <data name="ThereAreNoFactsWithCorrespondingStreetcodeId" xml:space="preserve">
+    <value>There are no facts with corresponding StreetcodeId = {0}</value>
+    <comment>format argument 0 - streetcode id</comment>
   </data>
 </root>


### PR DESCRIPTION
- Relocated Error Messages from CannotFindEntityErrors.resx and CannotUpdateEntityErrors.resx to ReorderFactErrors.resx
- Edited ReorderFactHandler.cs