### PR TITLE
Fix code smells in tests for GetAll and GetById handlers

### DIFF
--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
@@ -33,7 +33,7 @@ public interface IRepositoryBase<T>
 
     IQueryable<T> Include(params Expression<Func<T, object>>[] includes);
 
-    Task<IEnumerable<T>> GetAllAsync(
+    Task<IEnumerable<T>?> GetAllAsync(
         Expression<Func<T, bool>>? predicate = default,
         Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = default);
 

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -90,7 +90,7 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T>
         return (query is null) ? _dbContext.Set<T>() : query.AsQueryable();
     }
 
-    public async Task<IEnumerable<T>> GetAllAsync(
+    public async Task<IEnumerable<T>?> GetAllAsync(
         Expression<Func<T, bool>>? predicate = default,
         Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = default)
     {


### PR DESCRIPTION
Fix code smells in tests for GetAll and GetByIdHandlers.

Clean up these smells in code:
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&id=project-studying-dotnet_Streetcode-Admin-March-01

There are "Argument of type" exceptions  due to differences in the nullability of reference types in tests for GetAll and GetById handlers.
Change method GetAllAsync in 2 files IRepositoryBase.cs and RepositoryBase.cs:
Add "?" (nullable type) to return value.



![Image](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/assets/56700347/fe4f5433-f412-495c-9e95-012a92e9fa13)

