### PR TITLE
Investigate: Using an Action Filter for validation

### DIFF
--- a/Streetcode/Streetcode.BLL/ActionFilters/AsyncValidateEntityExistsAttribute.cs
+++ b/Streetcode/Streetcode.BLL/ActionFilters/AsyncValidateEntityExistsAttribute.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Contracts;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.ActionFilters;
+
+public class AsyncValidateEntityExistsAttribute<T> : IAsyncActionFilter
+    where T : class, IEntity
+{
+    private readonly IEntityRepositoryBase<T> _repositoryBase;
+    private readonly ILoggerService _logger;
+    public AsyncValidateEntityExistsAttribute(IEntityRepositoryBase<T> repositoryBase, ILoggerService logger)
+    {
+        _repositoryBase = repositoryBase;
+        _logger = logger;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        int id;
+        if (context.ActionArguments.ContainsKey("Id"))
+        {
+            id = (int)context.ActionArguments["Id"] !;
+        }
+        else
+        {
+            var errorMsg = string.Format(ErrorMessages.RequestDoesNotContainIdParameter, typeof(T).Name);
+            _logger.LogError(context, errorMsg);
+            context.Result = new BadRequestObjectResult(errorMsg);
+            return;
+        }
+
+        var entity = await _repositoryBase.GetSingleOrDefaultAsync(x => x.Id.Equals(id));
+
+        if (entity == null)
+        {
+            var requestType = context.HttpContext.Request.Headers[":method"];
+            string errorMessageType = GetErrorMessage(requestType);
+            var errorMsg = string.Format(errorMessageType, typeof(T).Name, id);
+            _logger.LogError(context, errorMsg);
+            context.Result = new NotFoundObjectResult(errorMsg);
+            return;
+        }
+        else
+        {
+            context.HttpContext.Items.Add("entity", entity);
+        }
+
+        var result = await next();
+    }
+
+    private string GetErrorMessage(string requestType) => requestType switch
+    {
+        "GET" => ErrorMessages.EntityByIdNotFound,
+        "PUT" => ErrorMessages.UpdateFailed,
+        "DELETE" => ErrorMessages.DeleteFailed,
+        _ => "Not appropriate Request type",
+    };
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/FactProfile.cs
@@ -10,5 +10,6 @@ public class FactProfile : Profile
     {
         CreateMap<Fact, FactDto>().ReverseMap();
         CreateMap<Fact, CreateFactDto>().ReverseMap();
+        CreateMap<Fact, FactForUpdateDto>().ReverseMap();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Partners/Delete/DeletePartnerHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Partners/Delete/DeletePartnerHandler.cs
@@ -23,26 +23,19 @@ namespace Streetcode.BLL.MediatR.Partners.Delete
         public async Task<Result<PartnerDto>> Handle(DeletePartnerQuery request, CancellationToken cancellationToken)
         {
             var partner = await _repositoryWrapper.PartnersRepository.GetFirstOrDefaultAsync(p => p.Id == request.id);
-            if (partner == null)
+            _repositoryWrapper.PartnersRepository.Delete(partner);
+            try
             {
-                const string errorMsg = "No partner with such id";
-                _logger.LogError(request, errorMsg);
-                return Result.Fail(errorMsg);
+                await _repositoryWrapper.SaveChangesAsync();
+                return Result.Ok(_mapper.Map<PartnerDto>(partner));
             }
-            else
+            catch (Exception ex)
             {
-                _repositoryWrapper.PartnersRepository.Delete(partner);
-                try
-                {
-                    await _repositoryWrapper.SaveChangesAsync();
-                    return Result.Ok(_mapper.Map<PartnerDto>(partner));
-                }
-                catch(Exception ex)
-                {
-                    _logger.LogError(request, ex.Message);
-                    return Result.Fail(ex.Message);
-                }
+                _logger.LogError(request, ex.Message);
+                return Result.Fail(ex.Message);
             }
+
+            // }
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Partners/GetById/GetPartnerByIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Partners/GetById/GetPartnerByIdHandler.cs
@@ -30,13 +30,6 @@ public class GetPartnerByIdHandler : IRequestHandler<GetPartnerByIdQuery, Result
                 include: p => p
                     .Include(pl => pl.PartnerSourceLinks));
 
-        if (partner is null)
-        {
-            string errorMsg = $"Cannot find any partner with corresponding id: {request.Id}";
-            _logger.LogError(request, errorMsg);
-            return Result.Fail(new Error(errorMsg));
-        }
-
         return Result.Ok(_mapper.Map<PartnerDto>(partner));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Delete/DeleteFactHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Delete/DeleteFactHandler.cs
@@ -21,19 +21,6 @@ public class DeleteFactHandler : IRequestHandler<DeleteFactCommand, Result<Unit>
     {
         int id = request.Id;
         var fact = await _repositoryWrapper.FactRepository.GetFirstOrDefaultAsync(x => x.Id == id);
-
-        if (fact is null)
-        {
-            string errorMsg = string.Format(
-                ErrorMessages.EntityByIdNotFound,
-                nameof(Fact),
-                request.Id);
-
-            _logger.LogError(request, errorMsg);
-
-            return Result.Fail(errorMsg);
-        }
-
         _repositoryWrapper.FactRepository.Delete(fact);
 
         var resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/GetById/GetFactByIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/GetById/GetFactByIdHandler.cs
@@ -24,19 +24,6 @@ public class GetFactByIdHandler : IRequestHandler<GetFactByIdQuery, Result<FactD
     public async Task<Result<FactDto>> Handle(GetFactByIdQuery request, CancellationToken cancellationToken)
     {
         var fact = await _repositoryWrapper.FactRepository.GetFirstOrDefaultAsync(f => f.Id == request.Id);
-
-        if (fact is null)
-        {
-            string errorMsg = string.Format(
-                ErrorMessages.EntityByIdNotFound,
-                nameof(Fact),
-                request.Id);
-
-            _logger.LogError(request, errorMsg);
-
-            return Result.Fail(new Error(errorMsg));
-        }
-
         return Result.Ok(_mapper.Map<FactDto>(fact));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
@@ -76,7 +76,9 @@ public sealed class ReorderFactHandler : IRequestHandler<ReorderFactCommand, Res
     private Result<ReorderFactResponseDto> CannotFindFactsWithStreetcodeId(ReorderFactRequestDto request)
     {
         var errorMsg = string.Format(
-            Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.ThereAreNoFactsWithCorrespondingStreetcodeId,
+            Resources.Errors.ErrorMessages.EntitiesByIdNotFound,
+            nameof(Fact),
+            nameof(Streetcode),
             request.StreetcodeId);
         _logger.LogError(request, errorMsg);
         return Result.Fail(errorMsg);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Reorder/ReorderFactHandler.cs
@@ -107,7 +107,11 @@ public sealed class ReorderFactHandler : IRequestHandler<ReorderFactCommand, Res
 
     private Result<ReorderFactResponseDto> CannotUpdateFactsAfterReordering(ReorderFactRequestDto request)
     {
-        var errorMsg = string.Format(Resources.Errors.ValidationErrors.Fact.ReorderFactErrors.CannotUpdateNumberInFact);
+        var errorMsg = string.Format(
+            Resources.Errors.ErrorMessages.UpdateEntitiesFailed,
+            nameof(Fact),
+            nameof(Streetcode),
+            request.StreetcodeId);
         _logger.LogError(request, errorMsg);
         return Result.Fail(errorMsg);
     }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Update/FactForUpdateHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Fact/Update/FactForUpdateHandler.cs
@@ -24,13 +24,6 @@ namespace Streetcode.BLL.MediatR.Streetcode.Fact.Update
 
             var image = await _repositoryWrapper.ImageRepository.GetFirstOrDefaultAsync(i => i.Id == request.ImageId);
 
-            if (fact is null)
-            {
-                string error = "Failed to find fact";
-                _logger.LogError(query, error);
-                return Result.Fail(error);
-            }
-
             if (image is not null)
             {
                 fact.ImageId = request.ImageId;

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
@@ -106,6 +106,15 @@ namespace Streetcode.BLL.Resources.Errors {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Request to {0} does not contain an id parameter.
+        /// </summary>
+        public static string RequestDoesNotContainIdParameter {
+            get {
+                return ResourceManager.GetString("RequestDoesNotContainIdParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to update the {0}s with {1}Id: {2}.
         /// </summary>
         public static string UpdateEntitiesFailed {

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
@@ -79,7 +79,7 @@ namespace Streetcode.BLL.Resources.Errors {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find {0}s with {1}Id: {2}.
+        ///   Looks up a localized string similar to Cannot find the {0}s with {1}Id: {2}.
         /// </summary>
         public static string EntitiesByIdNotFound {
             get {
@@ -102,6 +102,15 @@ namespace Streetcode.BLL.Resources.Errors {
         public static string EntityByIdNotFound {
             get {
                 return ResourceManager.GetString("EntityByIdNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update the {0}s with {1}Id: {2}.
+        /// </summary>
+        public static string UpdateEntitiesFailed {
+            get {
+                return ResourceManager.GetString("UpdateEntitiesFailed", resourceCulture);
             }
         }
         

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
@@ -79,6 +79,15 @@ namespace Streetcode.BLL.Resources.Errors {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot find {0}s with {1}Id: {2}.
+        /// </summary>
+        public static string EntitiesByIdNotFound {
+            get {
+                return ResourceManager.GetString("EntitiesByIdNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find any {0}s.
         /// </summary>
         public static string EntitiesNotFound {

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
@@ -137,6 +137,10 @@
     <value>Cannot find {0} with id: {1}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - request id</comment>
   </data>
+  <data name="RequestDoesNotContainIdParameter" xml:space="preserve">
+    <value>Request to {0} does not contain an id parameter</value>
+    <comment>format: 0 - nameof(EntityClass)</comment>
+  </data>
   <data name="UpdateEntitiesFailed" xml:space="preserve">
     <value>Failed to update the {0}s with {1}Id: {2}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - nameof(EntityClass), 2 - request id</comment>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
@@ -126,7 +126,7 @@
     <comment>format: 0 - nameof(EntityClass), 1 - request id</comment>
   </data>
   <data name="EntitiesByIdNotFound" xml:space="preserve">
-    <value>Cannot find {0}s with {1}Id: {2}</value>
+    <value>Cannot find the {0}s with {1}Id: {2}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - nameof(EntityClass), 2 - request id</comment>
   </data>
   <data name="EntitiesNotFound" xml:space="preserve">
@@ -136,6 +136,10 @@
   <data name="EntityByIdNotFound" xml:space="preserve">
     <value>Cannot find {0} with id: {1}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - request id</comment>
+  </data>
+  <data name="UpdateEntitiesFailed" xml:space="preserve">
+    <value>Failed to update the {0}s with {1}Id: {2}</value>
+    <comment>format: 0 - nameof(EntityClass), 1 - nameof(EntityClass), 2 - request id</comment>
   </data>
   <data name="UpdateFailed" xml:space="preserve">
     <value>Failed to update the {0} with id: {1}</value>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
@@ -125,6 +125,10 @@
     <value>Failed to delete the {0} with id: {1}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - request id</comment>
   </data>
+  <data name="EntitiesByIdNotFound" xml:space="preserve">
+    <value>Cannot find {0}s with {1}Id: {2}</value>
+    <comment>format: 0 - nameof(EntityClass), 1 - nameof(EntityClass), 2 - request id</comment>
+  </data>
   <data name="EntitiesNotFound" xml:space="preserve">
     <value>Cannot find any {0}s</value>
     <comment>format: 0 - nameof(EntityClass)</comment>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
@@ -70,7 +70,7 @@ namespace Streetcode.BLL.Resources.Errors.ValidationErrors.Fact {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fact with Id={0} does not exist or has StreetcodeId different from {1}.
+        ///   Looks up a localized string similar to Fact with Id={0} does not exist or it has StreetcodeId &lt;&gt; {1}.
         /// </summary>
         public static string IncorrectFactIdInArray {
             get {

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.Designer.cs
@@ -61,15 +61,6 @@ namespace Streetcode.BLL.Resources.Errors.ValidationErrors.Fact {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot update property Number in fact.
-        /// </summary>
-        public static string CannotUpdateNumberInFact {
-            get {
-                return ResourceManager.GetString("CannotUpdateNumberInFact", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The incoming array of Ids is null or has no elements..
         /// </summary>
         public static string IncomingFactIdArrIsNullOrEmpty {
@@ -93,15 +84,6 @@ namespace Streetcode.BLL.Resources.Errors.ValidationErrors.Fact {
         public static string IncorrectIdsNumberInArray {
             get {
                 return ResourceManager.GetString("IncorrectIdsNumberInArray", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There are no facts with corresponding StreetcodeId = {0}.
-        /// </summary>
-        public static string ThereAreNoFactsWithCorrespondingStreetcodeId {
-            get {
-                return ResourceManager.GetString("ThereAreNoFactsWithCorrespondingStreetcodeId", resourceCulture);
             }
         }
     }

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CannotUpdateNumberInFact" xml:space="preserve">
-    <value>Cannot update property Number in fact</value>
-  </data>
   <data name="IncomingFactIdArrIsNullOrEmpty" xml:space="preserve">
     <value>The incoming array of Ids is null or has no elements.</value>
   </data>
@@ -135,9 +132,5 @@ argument 1 - streetcode id</comment>
 argument 0 - number of IDs transferred in the array
 argument 1 - number of facts for the StreetcodeContent with a certain StreetcodeId
 argument 2 - StreetcodeId</comment>
-  </data>
-  <data name="ThereAreNoFactsWithCorrespondingStreetcodeId" xml:space="preserve">
-    <value>There are no facts with corresponding StreetcodeId = {0}</value>
-    <comment>format argument 0 - streetcode id</comment>
   </data>
 </root>

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ValidationErrors/Fact/ReorderFactErrors.resx
@@ -121,7 +121,7 @@
     <value>The incoming array of Ids is null or has no elements.</value>
   </data>
   <data name="IncorrectFactIdInArray" xml:space="preserve">
-    <value>Fact with Id={0} does not exist or has StreetcodeId different from {1}</value>
+    <value>Fact with Id={0} does not exist or it has StreetcodeId &lt;&gt; {1}</value>
     <comment>format:
 argument 0 - fact id
 argument 1 - streetcode id</comment>

--- a/Streetcode/Streetcode.DAL/Contracts/IEntity.cs
+++ b/Streetcode/Streetcode.DAL/Contracts/IEntity.cs
@@ -1,0 +1,6 @@
+﻿namespace Streetcode.DAL.Contracts;
+
+public interface IEntity
+{
+    int Id { get; set; }
+}

--- a/Streetcode/Streetcode.DAL/Entities/Partners/Partner.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Partners/Partner.cs
@@ -1,12 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Streetcode.DAL.Contracts;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Streetcode;
 
 namespace Streetcode.DAL.Entities.Partners;
 
 [Table("partners", Schema = "partners")]
-public class Partner
+public class Partner : IEntity
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/Fact.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/Fact.cs
@@ -1,11 +1,12 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Streetcode.DAL.Contracts;
 using Streetcode.DAL.Entities.Media.Images;
 
 namespace Streetcode.DAL.Entities.Streetcode.TextContent;
 
 [Table("facts", Schema = "streetcode")]
-public class Fact
+public class Fact : IEntity
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IEntityRepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IEntityRepositoryBase.cs
@@ -1,0 +1,9 @@
+﻿using Streetcode.DAL.Contracts;
+using Streetcode.DAL.Repositories.Realizations.Base;
+
+namespace Streetcode.DAL.Repositories.Interfaces.Base;
+
+public interface IEntityRepositoryBase<T> : IRepositoryBase<T>
+    where T : class, IEntity
+{
+}

--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
@@ -1,8 +1,6 @@
 using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Query;
-using Streetcode.DAL.Persistence;
 
 namespace Streetcode.DAL.Repositories.Interfaces.Base;
 

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/EntityRepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/EntityRepositoryBase.cs
@@ -1,0 +1,14 @@
+﻿using Streetcode.DAL.Contracts;
+using Streetcode.DAL.Persistence;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.DAL.Repositories.Realizations.Base;
+
+public class EntityRepositoryBase<T> : RepositoryBase<T>, IEntityRepositoryBase<T>
+    where T : class, IEntity
+{
+    public EntityRepositoryBase(StreetcodeDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -2,7 +2,6 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Query;
-using MimeKit;
 using Streetcode.DAL.Persistence;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 

--- a/Streetcode/Streetcode.WebApi/Controllers/Partners/PartnersController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Partners/PartnersController.cs
@@ -13,7 +13,6 @@ namespace Streetcode.WebApi.Controllers.Partners;
 public class PartnersController : BaseApiController
 {
     [HttpGet]
-    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Partner>))]
     public async Task<IActionResult> GetAll()
     {
         return HandleResult(await Mediator.Send(new GetAllPartnersQuery()));

--- a/Streetcode/Streetcode.WebApi/Controllers/Partners/PartnersController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Partners/PartnersController.cs
@@ -1,16 +1,19 @@
 using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.ActionFilters;
 using Streetcode.BLL.Dto.Partners;
 using Streetcode.BLL.MediatR.Partners.Create;
 using Streetcode.BLL.MediatR.Partners.GetAll;
 using Streetcode.BLL.MediatR.Partners.GetAllPartnerShort;
 using Streetcode.BLL.MediatR.Partners.GetById;
 using Streetcode.BLL.MediatR.Partners.GetByStreetcodeId;
+using Streetcode.DAL.Entities.Partners;
 
 namespace Streetcode.WebApi.Controllers.Partners;
 
 public class PartnersController : BaseApiController
 {
     [HttpGet]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Partner>))]
     public async Task<IActionResult> GetAll()
     {
         return HandleResult(await Mediator.Send(new GetAllPartnersQuery()));
@@ -23,6 +26,7 @@ public class PartnersController : BaseApiController
     }
 
     [HttpGet("{id:int}")]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Partner>))]
     public async Task<IActionResult> GetById([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new GetPartnerByIdQuery(id)));
@@ -41,12 +45,14 @@ public class PartnersController : BaseApiController
     }
 
     [HttpPut]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Partner>))]
     public async Task<IActionResult> Update([FromBody] CreatePartnerDto partner)
     {
         return HandleResult(await Mediator.Send(new BLL.MediatR.Partners.Update.UpdatePartnerQuery(partner)));
     }
 
     [HttpDelete("{id:int}")]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Partner>))]
     public async Task<IActionResult> Delete([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new BLL.MediatR.Partners.Delete.DeletePartnerQuery(id)));

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/FactController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/FactController.cs
@@ -15,7 +15,6 @@ namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 public class FactController : BaseApiController
 {
     [HttpGet]
-    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Fact>))]
     public async Task<IActionResult> GetAll()
     {
         return HandleResult(await Mediator.Send(new GetAllFactsQuery()));

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/FactController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/FactController.cs
@@ -7,18 +7,22 @@ using Streetcode.BLL.MediatR.Streetcode.Fact.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Fact.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Fact.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Fact.Reorder;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.BLL.ActionFilters;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 
 public class FactController : BaseApiController
 {
     [HttpGet]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Fact>))]
     public async Task<IActionResult> GetAll()
     {
         return HandleResult(await Mediator.Send(new GetAllFactsQuery()));
     }
 
     [HttpGet("{id:int}")]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Fact>))]
     public async Task<IActionResult> GetById([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new GetFactByIdQuery(id)));
@@ -43,12 +47,14 @@ public class FactController : BaseApiController
     }
 
     [HttpPut]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Fact>))]
     public async Task<IActionResult> Update([FromBody] FactForUpdateDto updateRequest)
     {
         return HandleResult(await Mediator.Send(new FactForUpdateCommand(updateRequest)));
     }
 
     [HttpDelete("{id:int}")]
+    [ServiceFilter(typeof(AsyncValidateEntityExistsAttribute<Fact>))]
     public async Task<IActionResult> Delete([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new DeleteFactCommand(id)));

--- a/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ using Serilog.Events;
 using Streetcode.DAL.Contracts;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Streetcode.BLL.ActionFilters;
+using Streetcode.DAL.Entities.Partners;
 
 namespace Streetcode.WebApi.Extensions;
 
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IRepositoryWrapper, RepositoryWrapper>();
         services.AddScoped<IEntityRepositoryBase<Fact>, EntityRepositoryBase<Fact>>();
+        services.AddScoped<IEntityRepositoryBase<Partner>, EntityRepositoryBase<Partner>>();
     }
 
     public static void AddCustomServices(this IServiceCollection services)
@@ -110,6 +112,7 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddScoped<AsyncValidateEntityExistsAttribute<Fact>>();
+        services.AddScoped<AsyncValidateEntityExistsAttribute<Partner>>();
         services.AddLogging();
         services.AddControllers();
     }

--- a/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ using Streetcode.BLL.Services.Instagram;
 using Streetcode.BLL.Interfaces.Text;
 using Streetcode.BLL.Services.Text;
 using Serilog.Events;
+using Streetcode.DAL.Contracts;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Streetcode.BLL.ActionFilters;
 
 namespace Streetcode.WebApi.Extensions;
 
@@ -32,6 +35,7 @@ public static class ServiceCollectionExtensions
     public static void AddRepositoryServices(this IServiceCollection services)
     {
         services.AddScoped<IRepositoryWrapper, RepositoryWrapper>();
+        services.AddScoped<IEntityRepositoryBase<Fact>, EntityRepositoryBase<Fact>>();
     }
 
     public static void AddCustomServices(this IServiceCollection services)
@@ -105,6 +109,7 @@ public static class ServiceCollectionExtensions
             opt.MaxAge = TimeSpan.FromDays(30);
         });
 
+        services.AddScoped<AsyncValidateEntityExistsAttribute<Fact>>();
         services.AddLogging();
         services.AddControllers();
     }

--- a/Streetcode/Streetcode.WebApi/Program.cs
+++ b/Streetcode/Streetcode.WebApi/Program.cs
@@ -1,4 +1,5 @@
 using Hangfire;
+using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.WebApi.Extensions;
 using Streetcode.WebApi.Utils;
@@ -13,6 +14,10 @@ builder.Services.ConfigureBlob(builder);
 builder.Services.ConfigurePayment(builder);
 builder.Services.ConfigureInstagram(builder);
 builder.Services.ConfigureSerilog(builder);
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.SuppressModelStateInvalidFilter = true;
+});
 var app = builder.Build();
 
 if (app.Environment.EnvironmentName == "Local")

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Fact/ReorderFactHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Fact/ReorderFactHandlerTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Fact;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.Fact.Reorder;
+using Streetcode.BLL.Resources.Errors;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using System;
@@ -69,7 +70,9 @@ public class ReorderFactHandlerTests
         var result = await handler.Handle(new ReorderFactCommand(new ReorderFactRequestDto(ids, FAILEDSTREETCODEID)), CancellationToken.None);
         var actualErrorMessage = result.Errors[0].Message;
         var expectedErrorMessage = string.Format(
-           ReorderFactErrors.ThereAreNoFactsWithCorrespondingStreetcodeId,
+           ErrorMessages.EntitiesByIdNotFound,
+           nameof(Fact),
+           nameof(Streetcode),
            FAILEDSTREETCODEID);
 
         // Assert
@@ -140,7 +143,11 @@ public class ReorderFactHandlerTests
         // Act
         var result = await handler.Handle(new ReorderFactCommand(new ReorderFactRequestDto(ids, STREETCODEID)), CancellationToken.None);
         var actualErrorMessage = result.Errors[0].Message;
-        var expectedErrorMessage = string.Format(ReorderFactErrors.CannotUpdateNumberInFact);
+        var expectedErrorMessage = string.Format(
+            ErrorMessages.UpdateEntitiesFailed,
+            nameof(Fact),
+            nameof(Streetcode),
+            STREETCODEID);
 
         // Assert
         result.IsFailed.Should().BeTrue();


### PR DESCRIPTION

**[Guid (Using an Action Filter for validation).txt](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/files/14808660/Guid.Using.an.Action.Filter.for.validation.txt)**


Investigate: Using an Action Filter for validation.

Applied attribute (AsyncValidateEntityExistsAttribute) to the actions GetById, Update and Delete of two controllers - FactController and PartnerController.

I. FactController 
1) Created AsyncValidateEntityExistsAttribute<T> class and added it to FactController actions - GetById, Update, Delete; 
2) Created interface IEntity and made Fact followed this interface
3) Added to ServiceCollection a new RepositoryService - services.AddScoped<IEntityRepositoryBase<Fact>, EntityRepositoryBase<Fact>>();
4) Created interface IEntityRepositoryBase and class EntityRepositoryBase;
5) To suppress the default validation in Program.cs:
builder.Services.Configure<ApiBehaviorOptions>(options =>
{
    options.SuppressModelStateInvalidFilter = true;
});

II. PartnerController
1) Changed in AsyncValidateEntityExistsAttribute logic for processing Update action; 
2) Updated FactProfile (adding line - CreateMap<Fact, FactForUpdateDto>().ReverseMap();)
3) Added to ServiceCollection a new RepositoryService - services.AddScoped<IEntityRepositoryBase<Partner>, EntityRepositoryBase<Partner>>();
4) Placed attributes with type AsyncValidateEntityExistsAttribute<T> in the PartnerController
5) Removed AsyncValidateEntityExistsAttribute from GetAll action in controllers - Fact and Partner
6) Removed checking for null from methods GetById, Update, Create in controllers - Fact and Partner

III. TODO
Unit tests for AsyncValidateEntityExistsAttribute