### PR TITLE
fix bug and error messages in Timeline folder

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Timeline/HistoricalContext/GetAll/GetAllHistoricalContextHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Timeline/HistoricalContext/GetAll/GetAllHistoricalContextHandler.cs
@@ -1,10 +1,11 @@
 ﻿using AutoMapper;
 using FluentResults;
 using MediatR;
-using Streetcode.BLL.Dto.AdditionalContent.Subtitles;
 using Streetcode.BLL.Dto.Timeline;
 using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
 using Streetcode.DAL.Repositories.Interfaces.Base;
+using HistoricalContextEntity = Streetcode.DAL.Entities.Timeline.HistoricalContext;
 
 namespace Streetcode.BLL.MediatR.Timeline.HistoricalContext.GetAll
 {
@@ -29,8 +30,11 @@ namespace Streetcode.BLL.MediatR.Timeline.HistoricalContext.GetAll
 
             if (historicalContextItems is null)
             {
-                const string errorMsg = $"Cannot find any historical contexts";
+                string errorMsg = string.Format(
+                ErrorMessages.EntitiesNotFound,
+                typeof(HistoricalContextEntity).Name);
                 _logger.LogError(request, errorMsg);
+
                 return Result.Fail(new Error(errorMsg));
             }
 

--- a/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetAll/GetAllTimelineItemsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Timeline/TimelineItem/GetAll/GetAllTimelineItemsHandler.cs
@@ -2,11 +2,11 @@ using AutoMapper;
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Streetcode.BLL.Dto.AdditionalContent.Subtitles;
 using Streetcode.BLL.Dto.Timeline;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.DAL.Entities.AdditionalContent.Coordinates;
+using Streetcode.BLL.Resources.Errors;
 using Streetcode.DAL.Repositories.Interfaces.Base;
+using TimelineItemEntity = Streetcode.DAL.Entities.Timeline.TimelineItem;
 
 namespace Streetcode.BLL.MediatR.Timeline.TimelineItem.GetAll;
 
@@ -33,8 +33,11 @@ public class GetAllTimelineItemsHandler : IRequestHandler<GetAllTimelineItemsQue
 
         if (timelineItems is null)
         {
-            const string errorMsg = $"Cannot find any timelineItem";
+            string errorMsg = string.Format(
+                ErrorMessages.EntitiesNotFound,
+                typeof(TimelineItemEntity).Name);
             _logger.LogError(request, errorMsg);
+
             return Result.Fail(new Error(errorMsg));
         }
 


### PR DESCRIPTION
## Summary of issue
api/TimelineItem/GetById/{id} always returned item with id 1

## Summary of change
Fixed predicate for retrieving item
fixed error messages in Timeline folder