### PR TITLE
Implemented Update logic for text block with tests for it

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/UpdateTextRequestDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/UpdateTextRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+public sealed record UpdateTextRequestDto(int Id, string? Title, string? TextContent, string? AdditionalText);

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/UpdateTextResponseDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/UpdateTextResponseDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+public sealed record UpdateTextResponseDto(int Id, int StreetcodeId, string? Title, string? TextContent, string? AdditionalText);

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 
 namespace Streetcode.BLL.Mapping.Streetcode.TextContent;
@@ -10,5 +11,7 @@ public class TextProfile : Profile
     {
         CreateMap<Text, TextDto>().ReverseMap();
         CreateMap<TextCreateDto, Text>().ReverseMap();
+        CreateMap<UpdateTextRequestDto, Text>();
+        CreateMap<Text, UpdateTextResponseDto>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Update;
+
+public sealed record UpdateTextCommand(UpdateTextRequestDto Request) :
+    IRequest<Result<UpdateTextResponseDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextHandler.cs
@@ -1,0 +1,86 @@
+﻿using System.Text;
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using TextEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Update;
+
+public class UpdateTextHandler :
+    IRequestHandler<UpdateTextCommand, Result<UpdateTextResponseDto>>
+{
+    private const string PREFILLEDTEXT = "Текст підготовлений спільно з ";
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILoggerService _logger;
+
+    public UpdateTextHandler(IRepositoryWrapper repository, IMapper mapper, ILoggerService logger)
+    {
+        _repositoryWrapper = repository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<UpdateTextResponseDto>> Handle(UpdateTextCommand command, CancellationToken cancellationToken)
+    {
+        var request = command.Request;
+
+        var textToCreate = _mapper.Map<TextEntity>(request);
+
+        var existedText = await _repositoryWrapper.TextRepository
+            .GetFirstOrDefaultAsync(text => text.Id == request.Id);
+
+        if (existedText is null)
+        {
+            return TextNotFoundError(request);
+        }
+
+        textToCreate.StreetcodeId = existedText.StreetcodeId;
+
+        if (textToCreate.AdditionalText is not null && textToCreate.AdditionalText != string.Empty)
+        {
+            StringBuilder sb = new StringBuilder(PREFILLEDTEXT);
+            textToCreate.AdditionalText = sb.Append(textToCreate.AdditionalText).ToString();
+        }
+        else
+        {
+            textToCreate.AdditionalText = null;
+        }
+
+        _repositoryWrapper.TextRepository.Update(textToCreate);
+
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!resultIsSuccess)
+        {
+            return FailedToCreateTextError(request);
+        }
+
+        var responseDto = _mapper.Map<UpdateTextResponseDto>(textToCreate);
+
+        return Result.Ok(responseDto);
+    }
+
+    private Result<UpdateTextResponseDto> TextNotFoundError(UpdateTextRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.EntityByIdNotFound,
+            typeof(TextEntity).Name,
+            request.Id);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+
+    private Result<UpdateTextResponseDto> FailedToCreateTextError(UpdateTextRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.CreateFailed,
+            typeof(TextEntity).Name);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextRequestDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Update/UpdateTextRequestDtoValidator.cs
@@ -1,0 +1,27 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Update;
+
+public class UpdateTextRequestDtoValidator : AbstractValidator<UpdateTextRequestDto>
+{
+    private const int MAXTITLE = 50;
+    private const int MAXTEXTCONTENT = 15000;
+    private const int MAXADDITIONALTEXT = 200;
+
+    public UpdateTextRequestDtoValidator()
+    {
+        RuleFor(dto => dto.Title)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXTITLE);
+
+        RuleFor(dto => dto.TextContent)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXTEXTCONTENT);
+
+        RuleFor(dto => dto.AdditionalText)
+            .MaximumLength(MAXADDITIONALTEXT);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
@@ -1,10 +1,10 @@
-using FluentResults;
 using Microsoft.AspNetCore.Mvc;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetParsed;
+using Streetcode.BLL.MediatR.Streetcode.Text.Update;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 
@@ -32,5 +32,11 @@ public class TextController : BaseApiController
     public async Task<IActionResult> GetParsedText([FromQuery] string text)
     {
         return HandleResult(await Mediator.Send(new GetParsedTextForAdminPreviewCommand(text)));
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> Update([FromBody] UpdateTextRequestDto updateRequest)
+    {
+        return HandleResult(await Mediator.Send(new UpdateTextCommand(updateRequest)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/UpdateTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/UpdateTextHandlerTests.cs
@@ -1,0 +1,229 @@
+﻿using System.Linq.Expressions;
+using AutoMapper;
+using FluentAssertions;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Text.Update;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TextEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Text;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetCode.Text;
+
+public class UpdateTextHandlerTests
+{
+    private const int SUCCESSFULSAVE = 1;
+    private const int FAILEDSAVE = -1;
+    private const int MINLENGTH = 1;
+    private const string PREFILLEDTEXT = "Текст підготовлений спільно з ";
+
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    public UpdateTextHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_IfCommandHasValidInput()
+    {
+        // Arrange
+        var request = GetValidUpdateTextRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnNullInAdditionalTextProperty_IfAdditionalTextWasNull()
+    {
+        // Arrange
+        var request = new UpdateTextRequestDto(
+            Id: 1,
+            Title: new string('a', MINLENGTH),
+            TextContent: new string('a', MINLENGTH),
+            AdditionalText: null);
+
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+
+        SetupMock(request, SUCCESSFULSAVE);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.Null(result.Value.AdditionalText);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldContainPREFILLEDTEXTinAdditionalTextProperty_IfAdditionalTextWasNotNull()
+    {
+        // Arrange
+        var request = new UpdateTextRequestDto(
+            Id: 1,
+            Title: new string('a', MINLENGTH),
+            TextContent: new string('a', MINLENGTH),
+            AdditionalText: new string('a', MINLENGTH));
+
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+        string expextedAdditionalText = PREFILLEDTEXT + request.AdditionalText;
+
+        SetupMock(request, SUCCESSFULSAVE);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.Equal(expextedAdditionalText, result.Value.AdditionalText);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultOfCorrectType_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidUpdateTextRequest();
+        var expectedType = typeof(Result<UpdateTextResponseDto>);
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Should().BeOfType(expectedType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultFail_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidUpdateTextRequest();
+        SetupMock(request, FAILEDSAVE);
+
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSaveChangesAsyncOnce_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidUpdateTextRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = CreateHandler();
+        var command = new UpdateTextCommand(request);
+
+        // Act
+        await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(1));
+    }
+
+    private UpdateTextHandler CreateHandler()
+    {
+        return new UpdateTextHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupMock(UpdateTextRequestDto request, int saveChangesAsyncResult)
+    {
+        var text = request.AdditionalText switch
+        {
+            null => new TextEntity
+            {
+                Id = 1,
+                StreetcodeId = 1,
+                Title = new string('a', MINLENGTH),
+                TextContent = new string('a', MINLENGTH),
+                AdditionalText = null
+            },
+            _ => new TextEntity
+            {
+                Id = 1,
+                StreetcodeId = 1,
+                Title = new string('a', MINLENGTH),
+                TextContent = new string('a', MINLENGTH),
+                AdditionalText = new string('a', MINLENGTH)
+            }
+        };
+
+        var dtoResponseText = request.AdditionalText switch
+        {
+            null => new UpdateTextResponseDto(
+                Id: 1,
+                StreetcodeId: 1,
+                Title: new string('a', MINLENGTH),
+                TextContent: new string('a', MINLENGTH),
+                AdditionalText: null),
+            _ => new UpdateTextResponseDto(
+                Id: 1,
+                StreetcodeId: 1,
+                Title: new string('a', MINLENGTH),
+                TextContent: new string('a', MINLENGTH),
+                AdditionalText: PREFILLEDTEXT + new string('a', MINLENGTH))
+        };
+
+        _mockRepositoryWrapper.Setup(repo => repo.TextRepository.GetFirstOrDefaultAsync(
+                AnyEntityPredicate<TextEntity>(),
+                AnyEntityInclude<TextEntity>()))
+            .ReturnsAsync(text);
+
+        _mockRepositoryWrapper.Setup(repo => repo.TextRepository.Update(
+            It.IsAny<TextEntity>())).Returns(It.IsAny<EntityEntry<TextEntity>>());
+
+        _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChangesAsyncResult);
+
+        _mockMapper
+            .Setup(m => m.Map<TextEntity>(It.IsAny<UpdateTextRequestDto>())).Returns(text);
+
+        _mockMapper
+           .Setup(m => m.Map<UpdateTextResponseDto>(It.IsAny<TextEntity>())).Returns(dtoResponseText);
+    }
+
+    private static Expression<Func<TEntity, bool>> AnyEntityPredicate<TEntity>()
+    {
+        return It.IsAny<Expression<Func<TEntity, bool>>>();
+    }
+
+    private static Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> AnyEntityInclude<TEntity>()
+    {
+        return It.IsAny<Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>>();
+    }
+
+    private static UpdateTextRequestDto GetValidUpdateTextRequest()
+    {
+        return new(
+            Id: 1,
+            Title: new string('a', MINLENGTH),
+            TextContent: new string('a', MINLENGTH),
+            AdditionalText: new string('a', MINLENGTH));
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Text/UpdateTextRequestDtoTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Text/UpdateTextRequestDtoTests.cs
@@ -1,0 +1,100 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Update;
+using Xunit;
+
+namespace Streetcode.XUnitTest.ValidationTests.Streetcode.Text;
+
+public class UpdateTextRequestDtoTests
+{
+    private const int MINTEXTID = 1;
+    private const int MINTITLELENGTH = 1;
+    private const int MINTEXTCONTENTLENGTH = 1;
+    private const int MAXTITLELENGTH = 50;
+    private const int MAXTEXTCONTENTLENGTH = 15000;
+    private const int MAXADDITIONALTEXTLENGTH = 200;
+
+    private readonly UpdateTextRequestDtoValidator _validator;
+
+    public UpdateTextRequestDtoTests()
+    {
+        _validator = new UpdateTextRequestDtoValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXTITLELENGTH + 10000)]
+    public void Should_have_error_when_Title_length_is_greater_than_MAXTITLE_or_equel_Zero(int number)
+    {
+        // Arrange
+        var dto = new UpdateTextRequestDto(
+            Id: MINTEXTID,
+            Title: new string('a', number),
+            TextContent: new string('a', MINTEXTCONTENTLENGTH),
+            AdditionalText: new string('a', 1));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXTEXTCONTENTLENGTH + 10000)]
+    public void Should_have_error_when_TextContent_length_is_greater_than_MAXTEXTCONTENTLENGTH_or_equel_Zero(int number)
+    {
+        // Arrange
+        var dto = new UpdateTextRequestDto(
+                    Id: MINTEXTID,
+                    Title: new string('a', MINTITLELENGTH),
+                    TextContent: new string('a', number),
+                    AdditionalText: new string('a', 1));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.TextContent);
+    }
+
+    [Theory]
+    [InlineData(MAXADDITIONALTEXTLENGTH + 10)]
+    [InlineData(MAXADDITIONALTEXTLENGTH + 10000)]
+    public void Should_have_error_when_AdditionalText_length_is_greater_than_MAXADDITIONALTEXTLENGTH(int number)
+    {
+        // Arrange
+        var dto = new UpdateTextRequestDto(
+                    Id: MINTEXTID,
+                    Title: new string('a', MINTITLELENGTH),
+                    TextContent: new string('a', MINTEXTCONTENTLENGTH),
+                    AdditionalText: new string('a', number));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.AdditionalText);
+    }
+
+    [Fact]
+    public void Should_not_have_error_when_dto_is_valid()
+    {
+        // Arrange
+        var dto = new UpdateTextRequestDto(
+            Id: MINTEXTID,
+            Title: new string('a', MINTITLELENGTH),
+            TextContent: new string('a', MINTEXTCONTENTLENGTH),
+            AdditionalText: new string('a', 1));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Id);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Title);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.TextContent);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.AdditionalText);
+    }
+}


### PR DESCRIPTION
[User story](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/issues/54)

### **Have been DONE:** 

1) Created DTO:
- UpdateTextRequestDto record should contain: int Id, string? Title, string? TextContent, string? AdditionalText;
- UpdateTextResponseDto record should contain: int Id, int StreetcodeId, string? Title, string? TextContent, string? AdditionalText.

2) Added mapping in TextProfile:
CreateMap<UpdateTextRequestDto, Text>();
CreateMap<Text, UpdateTextResponseDto>();

3) Created Mediator Handlers:
- UpdateTextHandler and UpdateTextCommand;
- UpdateTextRequestDtoValidator for validation.

3) Created Endpoint:
Update - which would receive UpdateTextRequestDto and then - update Text entitie.

4) Created Tests for handlers:
- UpdateTextHandler tests.

5) Created Tests for FluentValidation:
- UpdateTextRequestDto tests.