### PR TITLE
Implemented Delete logic for text block with tests for it

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/DeleteTextRequestDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/DeleteTextRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+public sealed record DeleteTextRequestDto(int Id);

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/DeleteTextResponseDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Text/DeleteTextResponseDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+public sealed record DeleteTextResponseDto(bool IsDeleted);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Delete;
+
+public sealed record DeleteTextCommand(DeleteTextRequestDto Request) :
+    IRequest<Result<DeleteTextResponseDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextHandler.cs
@@ -1,0 +1,62 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using TextEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Delete;
+
+public class DeleteTextHandler :
+    IRequestHandler<DeleteTextCommand, Result<DeleteTextResponseDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ILoggerService _logger;
+
+    public DeleteTextHandler(IRepositoryWrapper repository, ILoggerService logger)
+    {
+        _repositoryWrapper = repository;
+        _logger = logger;
+    }
+
+    public async Task<Result<DeleteTextResponseDto>> Handle(DeleteTextCommand command, CancellationToken cancellationToken)
+    {
+        var request = command.Request;
+
+        var text = await _repositoryWrapper.TextRepository
+           .GetFirstOrDefaultAsync(sr => sr.Id == request.Id);
+
+        if (text is null)
+        {
+            string errorMsg = string.Format(
+            ErrorMessages.EntityByIdNotFound,
+            typeof(TextEntity).Name,
+            request.Id);
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(errorMsg);
+        }
+
+        _repositoryWrapper.TextRepository.Delete(text);
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!resultIsSuccess)
+        {
+            return FailedToDeleteTextError(request);
+        }
+
+        var responseDto = new DeleteTextResponseDto(true);
+
+        return Result.Ok(responseDto);
+    }
+
+    private Result<DeleteTextResponseDto> FailedToDeleteTextError(DeleteTextRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.DeleteFailed,
+            typeof(TextEntity).Name,
+            request.Id);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextRequestDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Delete/DeleteTextRequestDtoValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Delete;
+
+public class DeleteTextRequestDtoValidator : AbstractValidator<DeleteTextRequestDto>
+{
+    public DeleteTextRequestDtoValidator()
+    {
+        RuleFor(dto => dto.Id)
+            .GreaterThan(0);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
@@ -1,6 +1,6 @@
-using FluentResults;
 using Microsoft.AspNetCore.Mvc;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Delete;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetByStreetcodeId;
@@ -32,5 +32,11 @@ public class TextController : BaseApiController
     public async Task<IActionResult> GetParsedText([FromQuery] string text)
     {
         return HandleResult(await Mediator.Send(new GetParsedTextForAdminPreviewCommand(text)));
+    }
+
+    [HttpDelete]
+    public async Task<IActionResult> Delete([FromBody] DeleteTextRequestDto deleteRequest)
+    {
+        return HandleResult(await Mediator.Send(new DeleteTextCommand(deleteRequest)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/DeleteTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/DeleteTextHandlerTests.cs
@@ -1,0 +1,156 @@
+﻿using System.Linq.Expressions;
+using FluentAssertions;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Text.Delete;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TextEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Text;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetCode.Text;
+
+public class DeleteTextHandlerTests
+{
+    private const int SUCCESSFULSAVE = 1;
+    private const int FAILEDSAVE = -1;
+
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    public DeleteTextHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_IfCommandHasValidInput()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultOfCorrectType_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        var expectedType = typeof(Result<DeleteTextResponseDto>);
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Should().BeOfType(expectedType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultFail_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, FAILEDSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTextCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnErrorDeleteFailed_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, FAILEDSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTextCommand(request);
+
+        var expectedErrorMessage = string.Format(
+        ErrorMessages.DeleteFailed,
+        typeof(TextEntity).Name,
+        request.Id);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+        var actualErrorMessage = result.Errors[0].Message;
+
+        // Assert
+        Assert.Equal(expectedErrorMessage, actualErrorMessage);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSaveChangesAsyncOnce_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTextCommand(request);
+
+        // Act
+        await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(1));
+    }
+
+    private DeleteTextHandler DeleteHandler()
+    {
+        return new DeleteTextHandler(
+            _mockRepositoryWrapper.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupMock(DeleteTextRequestDto request, int saveChangesAsyncResult)
+    {
+        var text = new TextEntity { Id = 1 };
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TextRepository.GetFirstOrDefaultAsync(
+                AnyEntityPredicate<TextEntity>(),
+                AnyEntityInclude<TextEntity>()))
+            .ReturnsAsync(text);
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TextRepository.Delete(text));
+
+        _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChangesAsyncResult);
+    }
+
+    private static Expression<Func<TEntity, bool>> AnyEntityPredicate<TEntity>()
+    {
+        return It.IsAny<Expression<Func<TEntity, bool>>>();
+    }
+
+    private static Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> AnyEntityInclude<TEntity>()
+    {
+        return It.IsAny<Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>>();
+    }
+
+    private static DeleteTextRequestDto GetValidTextRecordRequest()
+    {
+        return new(Id: 1);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Text/DeleteTextRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Text/DeleteTextRequestDtoValidatorTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Delete;
+using Xunit;
+
+namespace Streetcode.XUnitTest.ValidationTests.Streetcode.Text;
+
+public class DeleteTextRequestDtoValidatorTests
+{
+    private const int MINID = 1;
+
+    private readonly DeleteTextRequestDtoValidator _validator;
+
+    public DeleteTextRequestDtoValidatorTests()
+    {
+        _validator = new DeleteTextRequestDtoValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MINID - 10000)]
+    public void Should_have_error_when_Id_is_zero_or_negative(int id)
+    {
+        // Arrange
+        var dto = new DeleteTextRequestDto(Id: id);
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Fact]
+    public void Should_not_have_error_when_dto_is_valid()
+    {
+        // Arrange
+        var dto = new DeleteTextRequestDto(Id: MINID);
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}


### PR DESCRIPTION
[User story](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/issues/54)

### **Have been DONE:** 

1) Created DTO:
- DeleteTextRequestDto record should contain: int Id;
- DeleteTextResponseDto record should contain: IsDeleted (bool);

2) Created Mediator Handlers:
- DeleteTextHandler and DeleteTextCommand;
- DeleteTextRequestDtoValidator for validation.

3) Created Endpoints:
- Delete - which would receive DeleteTextRequestDto and then return True if the extraction was successful or False if it failed.

4) Created Tests for handlers:
- DeleteTextHandler tests.

5) Created Tests for FluentValidation:
- DeleteTextRequestDtoValidator tests.