### PR TITLE
Implemented Create logic for Term block with tests for it

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/CreateTermRequestDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/CreateTermRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record CreateTermRequestDto(string? Title, string? Description);

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/CreateTermResponseDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/CreateTermResponseDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record CreateTermResponseDto(int Id, string? Title, string? Description);

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Streetcode.BLL.Dto.Streetcode.TextContent;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 
 namespace Streetcode.BLL.Mapping.Streetcode.TextContent;
@@ -9,5 +10,7 @@ public class TermProfile : Profile
     public TermProfile()
     {
         CreateMap<Term, TermDto>().ReverseMap();
+        CreateMap<CreateTermRequestDto, Term>();
+        CreateMap<Term, CreateTermResponseDto>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Create;
+
+public sealed record CreateTermCommand(CreateTermRequestDto Request) :
+    IRequest<Result<CreateTermResponseDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermHandler.cs
@@ -12,7 +12,6 @@ namespace Streetcode.BLL.MediatR.Streetcode.Term.Create;
 public class CreateTermHandler :
     IRequestHandler<CreateTermCommand, Result<CreateTermResponseDto>>
 {
-    private const string PREFILLEDTEXT = "Текст підготовлений спільно з ";
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IMapper _mapper;
     private readonly ILoggerService _logger;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermHandler.cs
@@ -1,0 +1,79 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Create;
+
+public class CreateTermHandler :
+    IRequestHandler<CreateTermCommand, Result<CreateTermResponseDto>>
+{
+    private const string PREFILLEDTEXT = "Текст підготовлений спільно з ";
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILoggerService _logger;
+
+    public CreateTermHandler(IRepositoryWrapper repository, IMapper mapper, ILoggerService logger)
+    {
+        _repositoryWrapper = repository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<CreateTermResponseDto>> Handle(CreateTermCommand command, CancellationToken cancellationToken)
+    {
+        var request = command.Request;
+
+        if (!await IsTermTitleUniqueAsync(request.Title))
+        {
+            return TermTitleIsNotUniqueError(request);
+        }
+
+        var termToCreate = _mapper.Map<TermEntity>(request);
+
+        var term = _repositoryWrapper.TermRepository.Create(termToCreate);
+
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!resultIsSuccess)
+        {
+            return FailedToCreateTermError(request);
+        }
+
+        var responseDto = _mapper.Map<CreateTermResponseDto>(term);
+
+        return Result.Ok(responseDto);
+    }
+
+    private Result<CreateTermResponseDto> FailedToCreateTermError(CreateTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.CreateFailed,
+            typeof(TermEntity).Name);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+
+    private async Task<bool> IsTermTitleUniqueAsync(string? title)
+    {
+        var term = await _repositoryWrapper.TermRepository
+            .GetFirstOrDefaultAsync(term => term.Title == title);
+
+        return term is null;
+    }
+
+    private Result<CreateTermResponseDto> TermTitleIsNotUniqueError(CreateTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.PropertyMustBeUnique,
+            nameof(request.Title),
+            request.Title,
+            typeof(TermEntity).Name);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermRequestDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Create/CreateTermRequestDtoValidator.cs
@@ -1,0 +1,23 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Create;
+
+public class CreateTermRequestDtoValidator : AbstractValidator<CreateTermRequestDto>
+{
+    private const int MAXTITLE = 50;
+    private const int MAXDESCRIPTION = 500;
+
+    public CreateTermRequestDtoValidator()
+    {
+        RuleFor(dto => dto.Title)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXTITLE);
+
+        RuleFor(dto => dto.Description)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXDESCRIPTION);
+    }
+}

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.Designer.cs
@@ -151,6 +151,15 @@ namespace Streetcode.BLL.Resources.Errors {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value of property {0} = {1} is not unique in {2}.
+        /// </summary>
+        public static string PropertyMustBeUnique {
+            get {
+                return ResourceManager.GetString("PropertyMustBeUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to update the {0} with id: {1}.
         /// </summary>
         public static string UpdateFailed {

--- a/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
+++ b/Streetcode/Streetcode.BLL/Resources/Errors/ErrorMessages.resx
@@ -157,6 +157,10 @@
     <value>Primary Key of the {0} is not unique</value>
     <comment>format: 0 - nameof(EntityClass)</comment>
   </data>
+  <data name="PropertyMustBeUnique" xml:space="preserve">
+    <value>Value of property {0} = {1} is not unique in {2}</value>
+    <comment>format: 0 - nameof(Property), 1 - value of Property, 2 - nameof(EntityClass)</comment>
+  </data>
   <data name="UpdateFailed" xml:space="preserve">
     <value>Failed to update the {0} with id: {1}</value>
     <comment>format: 0 - nameof(EntityClass), 1 - request id</comment>

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.MediatR.Streetcode.Term.Create;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetById;
 
@@ -17,5 +18,11 @@ public class TermController : BaseApiController
     public async Task<IActionResult> GetById([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new GetTermByIdQuery(id)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateTermRequestDto createRequest)
+    {
+        return HandleResult(await Mediator.Send(new CreateTermCommand(createRequest)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/CreateTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/CreateTermHandlerTests.cs
@@ -1,0 +1,179 @@
+﻿using System.Linq.Expressions;
+using AutoMapper;
+using FluentAssertions;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Term.Create;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetCode.Term;
+
+public class CreateTermHandlerTests
+{
+    private const int SUCCESSFULSAVE = 1;
+    private const int FAILEDSAVE = -1;
+    private const int MINLENGTH = 1;
+
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    public CreateTermHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_IfCommandHasValidInput()
+    {
+        // Arrange
+        var request = GetValidCreateTermRequest();
+        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new CreateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCreateTermCommand_WithNotUniqueTermTitle_ShouldReturnSingleError()
+    {
+        // Arrange
+        var request = GetValidCreateTermRequest();
+        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: false);
+        string expectedErrorMsg = string.Format(
+            ErrorMessages.PropertyMustBeUnique,
+            nameof(request.Title),
+            request.Title,
+            typeof(TermEntity).Name);
+        var handler = CreateHandler();
+        var command = new CreateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMsg);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultOfCorrectType_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidCreateTermRequest();
+        var expectedType = typeof(Result<CreateTermResponseDto>);
+        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new CreateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Should().BeOfType(expectedType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultFail_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidCreateTermRequest();
+        SetupMock(request, FAILEDSAVE, isUniqueTermTitle: true);
+
+        var handler = CreateHandler();
+        var command = new CreateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSaveChangesAsyncOnce_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidCreateTermRequest();
+        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new CreateTermCommand(request);
+
+        // Act
+        await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(1));
+    }
+
+    private CreateTermHandler CreateHandler()
+    {
+        return new CreateTermHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupMock(CreateTermRequestDto request, int saveChangesAsyncResult, bool isUniqueTermTitle)
+    {
+        var validTerm = new TermEntity
+        {
+            Id = 1,
+            Title = new string('a', MINLENGTH),
+            Description = new string('a', MINLENGTH)
+        };
+        TermEntity? term = !isUniqueTermTitle ? validTerm : null;
+
+        var dtoResponseTerm = new CreateTermResponseDto(
+                Id: 1,
+                Title: new string('a', MINLENGTH),
+                Description: new string('a', MINLENGTH));
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TermRepository.GetFirstOrDefaultAsync(
+                AnyEntityPredicate<TermEntity>(),
+                AnyEntityInclude<TermEntity>()))
+            .ReturnsAsync(term);
+
+        _mockRepositoryWrapper.Setup(repo => repo.TermRepository.Create(
+            It.IsAny<TermEntity>())).Returns(validTerm);
+
+        _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChangesAsyncResult);
+
+        _mockMapper
+            .Setup(m => m.Map<TermEntity>(It.IsAny<CreateTermRequestDto>())).Returns(validTerm);
+        _mockMapper
+            .Setup(m => m.Map<CreateTermResponseDto>(It.IsAny<TermEntity>())).Returns(dtoResponseTerm);
+    }
+
+    private static Expression<Func<TEntity, bool>> AnyEntityPredicate<TEntity>()
+    {
+        return It.IsAny<Expression<Func<TEntity, bool>>>();
+    }
+
+    private static Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> AnyEntityInclude<TEntity>()
+    {
+        return It.IsAny<Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>>();
+    }
+
+    private static CreateTermRequestDto GetValidCreateTermRequest()
+    {
+        return new(
+            Title: new string('a', MINLENGTH),
+            Description: new string('a', MINLENGTH));
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/CreateTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/CreateTextHandlerTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using FluentResults;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
-using Streetcode.BLL.Dto.Streetcode.TextContent.Fact;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Text;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.Text.Create;

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
@@ -39,7 +39,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
-    public void Should_have_error_when_Description_length_is_greater_than_MAXTEXTCONTENTLENGTH_or_equel_Zero(int number)
+    public void ShouldHaveError_WhenDescriptionlengthIsGreaterThan_MAXTEXTCONTENTLENGTH_OrEquelZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(
@@ -54,7 +54,7 @@ public class CreateTermRequestDtoValidatorTests
     }
 
     [Fact]
-    public void Should_not_have_error_when_dto_is_valid()
+    public void ShouldNotHaveError_WhenDtoIsValid()
     {
         // Arrange
         var dto = new CreateTermRequestDto(

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
@@ -1,0 +1,71 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.MediatR.Streetcode.Term.Create;
+using Xunit;
+
+namespace Streetcode.XUnitTest.ValidationTests.Streetcode.Term;
+
+public class CreateTermRequestDtoValidatorTests
+{
+    private const int MINTITLELENGTH = 1;
+    private const int MINDESCRIPTIONLENGTH = 1;
+    private const int MAXTITLELENGTH = 50;
+    private const int MAXDESCRIPTIONLENGTH = 500;
+
+    private readonly CreateTermRequestDtoValidator _validator;
+
+    public CreateTermRequestDtoValidatorTests()
+    {
+        _validator = new CreateTermRequestDtoValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXTITLELENGTH + 10000)]
+    public void Should_have_error_when_Title_length_is_greater_than_MAXTITLE_or_equel_Zero(int number)
+    {
+        // Arrange
+        var dto = new CreateTermRequestDto(
+                    Title: new string('a', number),
+                    Description: new string('a', MINDESCRIPTIONLENGTH));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
+    public void Should_have_error_when_Description_length_is_greater_than_MAXTEXTCONTENTLENGTH_or_equel_Zero(int number)
+    {
+        // Arrange
+        var dto = new CreateTermRequestDto(
+                    Title: new string('a', MINTITLELENGTH),
+                    Description: new string('a', number));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Should_not_have_error_when_dto_is_valid()
+    {
+        // Arrange
+        var dto = new CreateTermRequestDto(
+            Title: new string('a', MINTITLELENGTH),
+            Description: new string('a', MINDESCRIPTIONLENGTH));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Title);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
@@ -22,7 +22,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXTITLELENGTH + 10000)]
-    public void Should_have_error_when_Title_length_is_greater_than_MAXTITLE_or_equel_Zero(int number)
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThan_MAXTITLE_OrEquelZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(


### PR DESCRIPTION
[User story](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/issues/54)

### **Have been DONE:** 

1) Created DTO:
- CreateTermRequestDto record should contain: string? Title, string? Description;
- CreateTermResponseDto record should contain: int Id, string? Title, string? Description.

2) Added mapping in TermProfile:
CreateMap<CreateTermRequestDto, Term>();
CreateMap<Term, CreateTermResponseDto>();

3) Created Mediator Handlers:
- CreateTermHandler and CreateTermCommand;
- CreateTermRequestDtoValidator for validation.

4) Created Endpoint:
- Create - which would receive CreateTermRequestDto and then create Term entitie.

5) Created Tests for handlers:
- CreateTermHandler tests.

6) Created Tests for FluentValidation:
- CreateTermRequestDtoValidator tests.

7) Added Error - PropertyMustBeUnique to ErrorMessages.resx