### PR TITLE
Implemented Update logic for Term block with tests for it

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/UpdateTermRequestDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/UpdateTermRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record UpdateTermRequestDto(int Id, string? Title, string? Description);

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/UpdateTermResponseDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/UpdateTermResponseDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record UpdateTermResponseDto(int Id, string? Title, string? Description);

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
@@ -12,5 +12,7 @@ public class TermProfile : Profile
         CreateMap<Term, TermDto>().ReverseMap();
         CreateMap<CreateTermRequestDto, Term>();
         CreateMap<Term, CreateTermResponseDto>();
+        CreateMap<UpdateTermRequestDto, Term>();
+        CreateMap<Term, UpdateTermResponseDto>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Update;
+
+public sealed record UpdateTermCommand(UpdateTermRequestDto Request) :
+    IRequest<Result<UpdateTermResponseDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermHandler.cs
@@ -37,9 +37,12 @@ public class UpdateTermHandler :
             return TermIsNotFoundError(request);
         }
 
-        if (!await IsTermTitleUniqueAsync(request.Title))
+        if (existedTerm.Title != request.Title)
         {
-            return TermTitleIsNotUniqueError(request);
+            if (!await IsTermTitleUniqueAsync(request.Title))
+            {
+                return TermTitleIsNotUniqueError(request);
+            }
         }
 
         _repositoryWrapper.TermRepository.Update(termToUpdate);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermHandler.cs
@@ -1,0 +1,96 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Update;
+
+public class UpdateTermHandler :
+    IRequestHandler<UpdateTermCommand, Result<UpdateTermResponseDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILoggerService _logger;
+
+    public UpdateTermHandler(IRepositoryWrapper repository, IMapper mapper, ILoggerService logger)
+    {
+        _repositoryWrapper = repository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<UpdateTermResponseDto>> Handle(UpdateTermCommand command, CancellationToken cancellationToken)
+    {
+        var request = command.Request;
+
+        var termToUpdate = _mapper.Map<TermEntity>(request);
+
+        var existedTerm = await _repositoryWrapper.TermRepository
+            .GetSingleOrDefaultAsync(term => term.Id == request.Id);
+
+        if (existedTerm is null)
+        {
+            return TermIsNotFoundError(request);
+        }
+
+        if (!await IsTermTitleUniqueAsync(request.Title))
+        {
+            return TermTitleIsNotUniqueError(request);
+        }
+
+        _repositoryWrapper.TermRepository.Update(termToUpdate);
+
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!resultIsSuccess)
+        {
+            return FailedToUpdateTermError(request);
+        }
+
+        var responseDto = _mapper.Map<UpdateTermResponseDto>(termToUpdate);
+
+        return Result.Ok(responseDto);
+    }
+
+    private Result<UpdateTermResponseDto> TermIsNotFoundError(UpdateTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.EntityByIdNotFound,
+            typeof(TermEntity).Name,
+            request.Id);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+
+    private Result<UpdateTermResponseDto> FailedToUpdateTermError(UpdateTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.CreateFailed,
+            typeof(TermEntity).Name);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+
+    private async Task<bool> IsTermTitleUniqueAsync(string? title)
+    {
+        var term = await _repositoryWrapper.TermRepository
+            .GetFirstOrDefaultAsync(term => term.Title == title);
+
+        return term is null;
+    }
+
+    private Result<UpdateTermResponseDto> TermTitleIsNotUniqueError(UpdateTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.PropertyMustBeUnique,
+            nameof(request.Title),
+            request.Title,
+            typeof(TermEntity).Name);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermRequestDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Update/UpdateTermRequestDtoValidator.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Update;
+
+public class UpdateTermRequestDtoValidator : AbstractValidator<UpdateTermRequestDto>
+{
+    private const int MAXTITLE = 50;
+    private const int MAXDESCRIPTION = 500;
+
+    public UpdateTermRequestDtoValidator()
+    {
+        RuleFor(dto => dto.Id)
+            .GreaterThan(0);
+
+        RuleFor(dto => dto.Title)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXTITLE);
+
+        RuleFor(dto => dto.Description)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(MAXDESCRIPTION);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
@@ -3,6 +3,7 @@ using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
 using Streetcode.BLL.MediatR.Streetcode.Term.Create;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetById;
+using Streetcode.BLL.MediatR.Streetcode.Term.Update;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 
@@ -24,5 +25,11 @@ public class TermController : BaseApiController
     public async Task<IActionResult> Create([FromBody] CreateTermRequestDto createRequest)
     {
         return HandleResult(await Mediator.Send(new CreateTermCommand(createRequest)));
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> Update([FromBody] UpdateTermRequestDto updateRequest)
+    {
+        return HandleResult(await Mediator.Send(new UpdateTermCommand(updateRequest)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/UpdateTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/UpdateTermHandlerTests.cs
@@ -202,7 +202,7 @@ public class UpdateTermHandlerTests
     {
         return new(
             Id: MINID,
-            Title: new string('a', MINLENGTH),
+            Title: new string('a', MINLENGTH + 1),
             Description: new string('a', MINLENGTH));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/UpdateTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/UpdateTermHandlerTests.cs
@@ -1,0 +1,208 @@
+﻿using System.Linq.Expressions;
+using AutoMapper;
+using FluentAssertions;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Term.Update;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetCode.Term;
+
+public class UpdateTermHandlerTests
+{
+    private const int SUCCESSFULSAVE = 1;
+    private const int FAILEDSAVE = -1;
+    private const int MINLENGTH = 1;
+    private const int MINID = 1;
+
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    public UpdateTermHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_IfCommandHasValidInput()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnPropertyMustBeUniqueError_IfInvalidUpdateTermCommandWithNotUniqueTermTitle()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: false);
+        string expectedErrorMsg = string.Format(
+            ErrorMessages.PropertyMustBeUnique,
+            nameof(request.Title),
+            request.Title,
+            typeof(TermEntity).Name);
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMsg);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEntityByIdNotFoundError_IfInvalidUpdateTermCommandWithNonExistentId()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        SetupMock(FAILEDSAVE, isUniqueTermTitle: true);
+        string expectedErrorMsg = string.Format(
+            ErrorMessages.EntityByIdNotFound,
+            typeof(TermEntity).Name,
+            request.Id);
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Errors.Should().ContainSingle(e => e.Message == expectedErrorMsg);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultOfCorrectType_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        var expectedType = typeof(Result<UpdateTermResponseDto>);
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Should().BeOfType(expectedType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultFail_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        SetupMock(FAILEDSAVE, isUniqueTermTitle: true);
+
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSaveChangesAsyncOnce_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidUpdateTermRequestDto();
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
+        var handler = CreateHandler();
+        var command = new UpdateTermCommand(request);
+
+        // Act
+        await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(1));
+    }
+
+    private UpdateTermHandler CreateHandler()
+    {
+        return new UpdateTermHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupMock(int saveChangesAsyncResult, bool isUniqueTermTitle)
+    {
+        var validTerm = new TermEntity
+        {
+            Id = MINID,
+            Title = new string('a', MINLENGTH),
+            Description = new string('a', MINLENGTH)
+        };
+        TermEntity? term = !isUniqueTermTitle ? validTerm : null;
+
+        var dtoResponseTerm = new UpdateTermResponseDto(
+                Id: MINID,
+                Title: new string('a', MINLENGTH),
+                Description: new string('a', MINLENGTH));
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TermRepository.GetSingleOrDefaultAsync(
+                AnyEntityPredicate<TermEntity>(),
+                AnyEntityInclude<TermEntity>()))
+            .ReturnsAsync(saveChangesAsyncResult == FAILEDSAVE ? null : validTerm);
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TermRepository.GetFirstOrDefaultAsync(
+                AnyEntityPredicate<TermEntity>(),
+                AnyEntityInclude<TermEntity>()))
+            .ReturnsAsync(term);
+
+        _mockRepositoryWrapper.Setup(repo => repo.TermRepository.Update(
+            It.IsAny<TermEntity>())).Returns(It.IsAny<EntityEntry<TermEntity>>());
+
+        _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChangesAsyncResult);
+
+        _mockMapper
+            .Setup(m => m.Map<TermEntity>(It.IsAny<UpdateTermRequestDto>())).Returns(validTerm);
+        _mockMapper
+            .Setup(m => m.Map<UpdateTermResponseDto>(It.IsAny<TermEntity>())).Returns(dtoResponseTerm);
+    }
+
+    private static Expression<Func<TEntity, bool>> AnyEntityPredicate<TEntity>()
+    {
+        return It.IsAny<Expression<Func<TEntity, bool>>>();
+    }
+
+    private static Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> AnyEntityInclude<TEntity>()
+    {
+        return It.IsAny<Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>>();
+    }
+
+    private static UpdateTermRequestDto GetValidUpdateTermRequestDto()
+    {
+        return new(
+            Id: MINID,
+            Title: new string('a', MINLENGTH),
+            Description: new string('a', MINLENGTH));
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
@@ -1,0 +1,94 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.MediatR.Streetcode.Term.Update;
+using Xunit;
+
+namespace Streetcode.XUnitTest.ValidationTests.Streetcode.Term;
+
+public class UpdateTermRequestDtoValidatorTests
+{
+    private const int MINTERMID = 1;
+    private const int MINTITLELENGTH = 1;
+    private const int MINDESCRIPTIONLENGTH = 1;
+    private const int MAXTITLELENGTH = 50;
+    private const int MAXDESCRIPTIONLENGTH = 500;
+
+    private readonly UpdateTermRequestDtoValidator _validator;
+
+    public UpdateTermRequestDtoValidatorTests()
+    {
+        _validator = new UpdateTermRequestDtoValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MINTERMID - 10000)]
+    public void ShouldHaveError_WhenIdIsZeroOrNegative(int id)
+    {
+        // Arrange
+        var dto = new UpdateTermRequestDto(
+            Id: id,
+            Title: new string('a', MINTITLELENGTH),
+            Description: new string('a', MINDESCRIPTIONLENGTH));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXTITLELENGTH + 10000)]
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThanMAXTITLEorEquelZero(int number)
+    {
+        // Arrange
+        var dto = new UpdateTermRequestDto(
+            Id: MINTERMID,
+            Title: new string('a', number),
+            Description: new string('a', MINDESCRIPTIONLENGTH));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
+    public void ShouldHaveError_WhenDescriptionLengthIsGreaterThanMAXDESCRIPTIONLENGTHOrEquelZero(int number)
+    {
+        // Arrange
+        var dto = new UpdateTermRequestDto(
+            Id: MINTERMID,
+            Title: new string('a', MINTITLELENGTH),
+            Description: new string('a', number));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void ShouldNotHaveError_WhenDtoIsValid()
+    {
+        // Arrange
+        var dto = new UpdateTermRequestDto(
+            Id: MINTERMID,
+            Title: new string('a', MINTITLELENGTH),
+            Description: new string('a', MINDESCRIPTIONLENGTH));
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Id);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Title);
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+}


### PR DESCRIPTION
[User story](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/issues/54)

### **Have been DONE:** 

1) Created DTO:
- UpdateTermRequestDto record should contain: int Id, string? Title, string? Description;
- UpdateTermResponseDto record should contain: int Id, string? Title, string? Description.

2) Added mapping in TermProfile:
CreateMap<UpdateTermRequestDto , Term>();
CreateMap<Term, UpdateTermResponseDto>();

3) Created Mediator Handler:
- UpdateTermHandler and UpdateTermCommand;
- UpdateTermRequestDtoValidator.

4) Created Endpoint:
- Update - which would receive UpdateTermRequestDto and then - update Term entitie.

5) Created Tests for handlers:
- UpdateTermHandler tests.

6) Created Tests for FluentValidation:
- UpdateTermRequestDtoValidator tests.