### PR TITLE
Implemented Delete logic for Term block with tests for it

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/DeleteTermRequestDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/DeleteTermRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record DeleteTermRequestDto(int Id);

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/DeleteTermResponseDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/TextContent/Term/DeleteTermResponseDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+public sealed record DeleteTermResponseDto(bool IsDeleted);

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TermProfile.cs
@@ -14,5 +14,7 @@ public class TermProfile : Profile
         CreateMap<Term, CreateTermResponseDto>();
         CreateMap<UpdateTermRequestDto, Term>();
         CreateMap<Term, UpdateTermResponseDto>();
+        CreateMap<DeleteTermRequestDto, Term>();
+        CreateMap<Term, DeleteTermResponseDto>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Delete;
+
+public sealed record DeleteTermCommand(DeleteTermRequestDto Request) :
+    IRequest<Result<DeleteTermResponseDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermHandler.cs
@@ -1,0 +1,62 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Delete;
+
+public class DeleteTermHandler :
+    IRequestHandler<DeleteTermCommand, Result<DeleteTermResponseDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ILoggerService _logger;
+
+    public DeleteTermHandler(IRepositoryWrapper repository, ILoggerService logger)
+    {
+        _repositoryWrapper = repository;
+        _logger = logger;
+    }
+
+    public async Task<Result<DeleteTermResponseDto>> Handle(DeleteTermCommand command, CancellationToken cancellationToken)
+    {
+        var request = command.Request;
+
+        var term = await _repositoryWrapper.TermRepository
+           .GetFirstOrDefaultAsync(sr => sr.Id == request.Id);
+
+        if (term is null)
+        {
+            string errorMsg = string.Format(
+            ErrorMessages.EntityByIdNotFound,
+            typeof(TermEntity).Name,
+            request.Id);
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(errorMsg);
+        }
+
+        _repositoryWrapper.TermRepository.Delete(term);
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!resultIsSuccess)
+        {
+            return FailedToDeleteTermError(request);
+        }
+
+        var responseDto = new DeleteTermResponseDto(true);
+
+        return Result.Ok(responseDto);
+    }
+
+    private Result<DeleteTermResponseDto> FailedToDeleteTermError(DeleteTermRequestDto request)
+    {
+        string errorMsg = string.Format(
+            ErrorMessages.DeleteFailed,
+            typeof(TermEntity).Name,
+            request.Id);
+        _logger.LogError(request, errorMsg);
+        return Result.Fail(errorMsg);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermRequestDtoValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Term/Delete/DeleteTermRequestDtoValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Term.Delete;
+
+public class DeleteTermRequestDtoValidator : AbstractValidator<DeleteTermRequestDto>
+{
+    public DeleteTermRequestDtoValidator()
+    {
+        RuleFor(dto => dto.Id)
+            .GreaterThan(0);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TermController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
 using Streetcode.BLL.MediatR.Streetcode.Term.Create;
+using Streetcode.BLL.MediatR.Streetcode.Term.Delete;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Term.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Term.Update;
@@ -31,5 +32,11 @@ public class TermController : BaseApiController
     public async Task<IActionResult> Update([FromBody] UpdateTermRequestDto updateRequest)
     {
         return HandleResult(await Mediator.Send(new UpdateTermCommand(updateRequest)));
+    }
+
+    [HttpDelete]
+    public async Task<IActionResult> Delete([FromBody] DeleteTermRequestDto deleteRequest)
+    {
+        return HandleResult(await Mediator.Send(new DeleteTermCommand(deleteRequest)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/DeleteTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/DeleteTermHandlerTests.cs
@@ -1,0 +1,157 @@
+﻿using System.Linq.Expressions;
+using FluentAssertions;
+using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Streetcode.Term.Delete;
+using Streetcode.BLL.Resources.Errors;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+using TermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.Term;
+
+namespace Streetcode.XUnitTest.MediatRTests.StreetCode.Term;
+
+public class DeleteTermHandlerTests
+{
+    private const int MINID = 1;
+    private const int SUCCESSFULSAVE = 1;
+    private const int FAILEDSAVE = -1;
+
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<ILoggerService> _mockLogger;
+
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    public DeleteTermHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockLogger = new Mock<ILoggerService>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnOkResult_IfCommandHasValidInput()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultOfCorrectType_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        var expectedType = typeof(Result<DeleteTermResponseDto>);
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.Should().BeOfType(expectedType);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnResultFail_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, FAILEDSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTermCommand(request);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnErrorDeleteFailed_IfSavingOperationFailed()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, FAILEDSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTermCommand(request);
+
+        var expectedErrorMessage = string.Format(
+        ErrorMessages.DeleteFailed,
+        typeof(TermEntity).Name,
+        request.Id);
+
+        // Act
+        var result = await handler.Handle(command, _cancellationToken);
+        var actualErrorMessage = result.Errors[0].Message;
+
+        // Assert
+        Assert.Equal(expectedErrorMessage, actualErrorMessage);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSaveChangesAsyncOnce_IfInputIsValid()
+    {
+        // Arrange
+        var request = GetValidTextRecordRequest();
+        SetupMock(request, SUCCESSFULSAVE);
+        var handler = DeleteHandler();
+        var command = new DeleteTermCommand(request);
+
+        // Act
+        await handler.Handle(command, _cancellationToken);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(1));
+    }
+
+    private DeleteTermHandler DeleteHandler()
+    {
+        return new DeleteTermHandler(
+            _mockRepositoryWrapper.Object,
+            _mockLogger.Object);
+    }
+
+    private void SetupMock(DeleteTermRequestDto request, int saveChangesAsyncResult)
+    {
+        var term = new TermEntity { Id = MINID };
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TermRepository.GetFirstOrDefaultAsync(
+                AnyEntityPredicate<TermEntity>(),
+                AnyEntityInclude<TermEntity>()))
+            .ReturnsAsync(term);
+
+        _mockRepositoryWrapper
+            .Setup(repo => repo.TermRepository.Delete(term));
+
+        _mockRepositoryWrapper.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChangesAsyncResult);
+    }
+
+    private static Expression<Func<TEntity, bool>> AnyEntityPredicate<TEntity>()
+    {
+        return It.IsAny<Expression<Func<TEntity, bool>>>();
+    }
+
+    private static Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> AnyEntityInclude<TEntity>()
+    {
+        return It.IsAny<Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>>();
+    }
+
+    private static DeleteTermRequestDto GetValidTextRecordRequest()
+    {
+        return new(Id: MINID);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/DeleteTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/DeleteTermRequestDtoValidatorTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Streetcode.TextContent.Term;
+using Streetcode.BLL.MediatR.Streetcode.Term.Delete;
+using Xunit;
+
+namespace Streetcode.XUnitTest.ValidationTests.Streetcode.Term;
+
+public class DeleteTermRequestDtoValidatorTests
+{
+    private const int MINID = 1;
+
+    private readonly DeleteTermRequestDtoValidator _validator;
+
+    public DeleteTermRequestDtoValidatorTests()
+    {
+        _validator = new DeleteTermRequestDtoValidator();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(MINID - 10000)]
+    public void ShouldHaveError_WhenIdIsZeroOrNegative(int id)
+    {
+        // Arrange
+        var dto = new DeleteTermRequestDto(Id: id);
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Fact]
+    public void ShouldNotHaveError_WhenDtoIsValid()
+    {
+        // Arrange
+        var dto = new DeleteTermRequestDto(Id: MINID);
+
+        // Act
+        var validationResult = _validator.TestValidate(dto);
+
+        // Assert
+        validationResult.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}


### PR DESCRIPTION
[User story](https://github.com/project-studying-dotnet/Streetcode-Admin-March-01/issues/54)

### **Have been DONE:** 

1) Created DTO:
- DeleteTermRequestDto record should contain: int Id;
- DeleteTermResponseDto record should contain: bool IsDeleted.

2) Added mapping in TermProfile:
CreateMap<DeleteTermRequestDto , Term>();
CreateMap<Term, DeleteTermResponseDto>();

3) Created Mediator Handlers:
- DeleteTermHandler and DeleteTermCommand;
- DeleteTermRequestDtoValidator for validation.

4) Created Endpoints:
- Delete - which would receive DeleteTermRequestDto and then return True if the extraction was successful or False if it failed.

5) Created Tests for handlers:
- DeleteTermHandler tests.

6) Created Tests for FluentValidation:
- DeleteTermRequestDtoValidator tests.