### PR TITLE
Renamed vars and test methods, deleted redundant parameters in methods of Text, Term, StreetcodeCoordinate and StatisticRecord blocks

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/Coordinates/Types/DeleteStreetcodeCoordinateHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/AdditionalContent/Coordinates/Types/DeleteStreetcodeCoordinateHandlerTests.cs
@@ -34,7 +34,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStreetcodeCoordinateRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStreetcodeCoordinateCommand(request);
 
@@ -51,7 +51,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
         // Arrange
         var request = GetValidDeleteStreetcodeCoordinateRequest();
         var expectedType = typeof(Result<DeleteStreetcodeCoordinateResponseDto>);
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStreetcodeCoordinateCommand(request);
 
@@ -67,7 +67,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStreetcodeCoordinateRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStreetcodeCoordinateCommand(request);
 
@@ -83,7 +83,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStreetcodeCoordinateRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStreetcodeCoordinateCommand(request);
 
@@ -105,7 +105,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStreetcodeCoordinateRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStreetcodeCoordinateCommand(request);
 
@@ -123,7 +123,7 @@ public class DeleteStreetcodeCoordinateHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupMock(DeleteStreetcodeCoordinateRequestDto request, int saveChangesAsyncResult)
+    private void SetupMock(int saveChangesAsyncResult)
     {
         var streetcodeCoordinate = new StreetcodeCoordinateEntity { Id = 1, StreetcodeId = 1, Longtitude = 1, Latitude = 1 };
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Analytics/StatisticRecord/DeleteStatisticRecordHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Analytics/StatisticRecord/DeleteStatisticRecordHandlerTests.cs
@@ -34,7 +34,7 @@ public class DeleteStatisticRecordHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStatisticRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStatisticRecordCommand(request);
 
@@ -51,7 +51,7 @@ public class DeleteStatisticRecordHandlerTests
         // Arrange
         var request = GetValidDeleteStatisticRecordRequest();
         var expectedType = typeof(Result<DeleteStatisticRecordResponseDto>);
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStatisticRecordCommand(request);
 
@@ -67,7 +67,7 @@ public class DeleteStatisticRecordHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStatisticRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStatisticRecordCommand(request);
 
@@ -83,7 +83,7 @@ public class DeleteStatisticRecordHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStatisticRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStatisticRecordCommand(request);
 
@@ -105,7 +105,7 @@ public class DeleteStatisticRecordHandlerTests
     {
         // Arrange
         var request = GetValidDeleteStatisticRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteStatisticRecordCommand(request);
 
@@ -123,7 +123,7 @@ public class DeleteStatisticRecordHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupMock(DeleteStatisticRecordRequestDto request, int saveChangesAsyncResult)
+    private void SetupMock(int saveChangesAsyncResult)
     {
         var statisticRecord = new StatisticRecordEntity { Id = 1, StreetcodeId = 1, StreetcodeCoordinateId = 1 };
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/CreateTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/CreateTermHandlerTests.cs
@@ -38,7 +38,7 @@ public class CreateTermHandlerTests
     {
         // Arrange
         var request = GetValidCreateTermRequest();
-        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
         var handler = CreateHandler();
         var command = new CreateTermCommand(request);
 
@@ -50,11 +50,11 @@ public class CreateTermHandlerTests
     }
 
     [Fact]
-    public async Task Handle_InvalidCreateTermCommand_WithNotUniqueTermTitle_ShouldReturnSingleError()
+    public async Task Handle_ShouldReturnSingleError_IfInvalidCreateTermCommandWithNotUniqueTermTitle()
     {
         // Arrange
         var request = GetValidCreateTermRequest();
-        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: false);
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: false);
         string expectedErrorMsg = string.Format(
             ErrorMessages.PropertyMustBeUnique,
             nameof(request.Title),
@@ -76,7 +76,7 @@ public class CreateTermHandlerTests
         // Arrange
         var request = GetValidCreateTermRequest();
         var expectedType = typeof(Result<CreateTermResponseDto>);
-        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
         var handler = CreateHandler();
         var command = new CreateTermCommand(request);
 
@@ -92,7 +92,7 @@ public class CreateTermHandlerTests
     {
         // Arrange
         var request = GetValidCreateTermRequest();
-        SetupMock(request, FAILEDSAVE, isUniqueTermTitle: true);
+        SetupMock(FAILEDSAVE, isUniqueTermTitle: true);
 
         var handler = CreateHandler();
         var command = new CreateTermCommand(request);
@@ -109,7 +109,7 @@ public class CreateTermHandlerTests
     {
         // Arrange
         var request = GetValidCreateTermRequest();
-        SetupMock(request, SUCCESSFULSAVE, isUniqueTermTitle: true);
+        SetupMock(SUCCESSFULSAVE, isUniqueTermTitle: true);
         var handler = CreateHandler();
         var command = new CreateTermCommand(request);
 
@@ -128,7 +128,7 @@ public class CreateTermHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupMock(CreateTermRequestDto request, int saveChangesAsyncResult, bool isUniqueTermTitle)
+    private void SetupMock(int saveChangesAsyncResult, bool isUniqueTermTitle)
     {
         var validTerm = new TermEntity
         {

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/DeleteTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Term/DeleteTermHandlerTests.cs
@@ -35,7 +35,7 @@ public class DeleteTermHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTermCommand(request);
 
@@ -52,7 +52,7 @@ public class DeleteTermHandlerTests
         // Arrange
         var request = GetValidTextRecordRequest();
         var expectedType = typeof(Result<DeleteTermResponseDto>);
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTermCommand(request);
 
@@ -68,7 +68,7 @@ public class DeleteTermHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTermCommand(request);
 
@@ -84,7 +84,7 @@ public class DeleteTermHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTermCommand(request);
 
@@ -106,7 +106,7 @@ public class DeleteTermHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTermCommand(request);
 
@@ -124,7 +124,7 @@ public class DeleteTermHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupMock(DeleteTermRequestDto request, int saveChangesAsyncResult)
+    private void SetupMock(int saveChangesAsyncResult)
     {
         var term = new TermEntity { Id = MINID };
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/DeleteTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/StreetCode/Text/DeleteTextHandlerTests.cs
@@ -34,7 +34,7 @@ public class DeleteTextHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTextCommand(request);
 
@@ -51,7 +51,7 @@ public class DeleteTextHandlerTests
         // Arrange
         var request = GetValidTextRecordRequest();
         var expectedType = typeof(Result<DeleteTextResponseDto>);
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTextCommand(request);
 
@@ -67,7 +67,7 @@ public class DeleteTextHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTextCommand(request);
 
@@ -83,7 +83,7 @@ public class DeleteTextHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, FAILEDSAVE);
+        SetupMock(FAILEDSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTextCommand(request);
 
@@ -105,7 +105,7 @@ public class DeleteTextHandlerTests
     {
         // Arrange
         var request = GetValidTextRecordRequest();
-        SetupMock(request, SUCCESSFULSAVE);
+        SetupMock(SUCCESSFULSAVE);
         var handler = DeleteHandler();
         var command = new DeleteTextCommand(request);
 
@@ -123,7 +123,7 @@ public class DeleteTextHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupMock(DeleteTextRequestDto request, int saveChangesAsyncResult)
+    private void SetupMock(int saveChangesAsyncResult)
     {
         var text = new TextEntity { Id = 1 };
 

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
@@ -22,7 +22,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXTITLELENGTH + 10000)]
-    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEquelZero(int number)
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEqualZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(
@@ -39,7 +39,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
-    public void ShouldHaveError_WhenDescriptionlengthIsGreaterThanAllowedOrEquelZero(int number)
+    public void ShouldHaveError_WhenDescriptionlengthIsGreaterThanAllowedOrEqualZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/CreateTermRequestDtoValidatorTests.cs
@@ -22,7 +22,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXTITLELENGTH + 10000)]
-    public void ShouldHaveError_WhenTitleLengthIsGreaterThan_MAXTITLE_OrEquelZero(int number)
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEquelZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(
@@ -39,7 +39,7 @@ public class CreateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
-    public void ShouldHaveError_WhenDescriptionlengthIsGreaterThan_MAXTEXTCONTENTLENGTH_OrEquelZero(int number)
+    public void ShouldHaveError_WhenDescriptionlengthIsGreaterThanAllowedOrEquelZero(int number)
     {
         // Arrange
         var dto = new CreateTermRequestDto(

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
@@ -41,7 +41,7 @@ public class UpdateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXTITLELENGTH + 10000)]
-    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEquelZero(int number)
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEqualZero(int number)
     {
         // Arrange
         var dto = new UpdateTermRequestDto(
@@ -59,7 +59,7 @@ public class UpdateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
-    public void ShouldHaveError_WhenDescriptionLengthIsGreaterThanAllowedOrEquelZero(int number)
+    public void ShouldHaveError_WhenDescriptionLengthIsGreaterThanAllowedOrEqualZero(int number)
     {
         // Arrange
         var dto = new UpdateTermRequestDto(

--- a/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/ValidationTests/Streetcode/Term/UpdateTermRequestDtoValidatorTests.cs
@@ -41,7 +41,7 @@ public class UpdateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXTITLELENGTH + 10000)]
-    public void ShouldHaveError_WhenTitleLengthIsGreaterThanMAXTITLEorEquelZero(int number)
+    public void ShouldHaveError_WhenTitleLengthIsGreaterThanAllowedOrEquelZero(int number)
     {
         // Arrange
         var dto = new UpdateTermRequestDto(
@@ -59,7 +59,7 @@ public class UpdateTermRequestDtoValidatorTests
     [Theory]
     [InlineData(0)]
     [InlineData(MAXDESCRIPTIONLENGTH + 10000)]
-    public void ShouldHaveError_WhenDescriptionLengthIsGreaterThanMAXDESCRIPTIONLENGTHOrEquelZero(int number)
+    public void ShouldHaveError_WhenDescriptionLengthIsGreaterThanAllowedOrEquelZero(int number)
     {
         // Arrange
         var dto = new UpdateTermRequestDto(


### PR DESCRIPTION
**Renamed vars and test methods, deleted redundant parameters in methods of Text, Term, StreetcodeCoordinate and StatisticRecord blocks**

1) Renamed var: textToCreate => textToUpdate in UpdateTextHandler;
2) Renamed test methods in CreateTermRequestDtoValidatorTests;
3) Renamed test methods in UpdateTermRequestDtoValidatorTests;
4) Renamed test methods and deleted redundant parameter in methods of CreateTermHandlerTests;
5) Deleted redundant parameter in methods of DeleteTermHandlerTests;
6) Deleted redundant parameter in methods of DeleteTextHandlerTests;
7) Deleted redundant parameter in methods of DeleteStreetcodeCoordinateHandlerTests;
8) Deleted redundant parameter in methods of DeleteStatisticRecordHandlerTests.
